### PR TITLE
Add asset path to file loader name

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,8 +66,7 @@ module.exports = {
           {
             loader: "file-loader",
             options: {
-              name: "[name].[ext]",
-              outputPath: "sds"
+              name: "[path][name].[ext]"
             }
           }
         ]


### PR DESCRIPTION
- Fixes conflict for files that have the same name but live in different directories.