### PR TITLE
refactor(search): start refacotoring of search component

### DIFF
--- a/src/stylesheets/components/_search.scss
+++ b/src/stylesheets/components/_search.scss
@@ -1,0 +1,16 @@
+/*******************************
+       USWDS OVERRIDES
+*******************************/
+.usa-search {
+  [type='submit'] {
+    @include u-bg('indigo-cool-60');
+    @include u-radius(0);
+    height: units(5);
+  }
+}
+
+[type='search'],
+.usa-search__input {
+  height: units(5);
+  border: 1px solid color('base-light');
+}

--- a/src/stylesheets/theme/_sds-theme-custom-styles.scss
+++ b/src/stylesheets/theme/_sds-theme-custom-styles.scss
@@ -42,6 +42,7 @@ SDS THEME CUSTOM STYLES
 @import '../components/alert';
 @import '../components/page';
 @import '../components/navbar';
+@import '../components/search';
 
 // Layouts
 // -------------------------------------


### PR DESCRIPTION
Adds overrides to uswds search instead of creating a new component.
This was done because changes in design only include color and spacing.