### PR TITLE
Fix for style leak on vertical card

### DIFF
--- a/src/stylesheets/components/_card.scss
+++ b/src/stylesheets/components/_card.scss
@@ -88,18 +88,17 @@
       @include u-text('semibold');
       @include u-font-family('sans');
       @include u-text('ink');
+      + span {
+        @include u-text("ink");
+        @include u-text("bold");
+        @include u-font("sans", "sm");
+      }
     }
 
-    span {
-      @include u-text('ink');
-      @include u-text('bold');
-      @include u-font('sans', 'sm');
-    }
-
-    p {
-      @include u-text('ink');
-      @include u-font('sans', 'sm');
-    }
+    // p {
+    //   @include u-text('ink');
+    //   @include u-font('sans', 'sm');
+    // }
 
     .sds-card__links {
       @include u-display('flex');


### PR DESCRIPTION
restricted special subtitle-like "span" styles to when span follows an "H" tag or "subtitle" class