### PR TITLE
Add styles to align chips with an input element

### DIFF
--- a/src/components/03-components/04-tags/tags--chip.njk
+++ b/src/components/03-components/04-tags/tags--chip.njk
@@ -19,7 +19,7 @@
 
 <h2>Input Chips</h2>
 
-<input aria-autocomplete="list" autocomplete="off" class="usa-input padding-right-3 margin-y-1" type="text" aria-label="Auto Complete" id="autocomplete5" placeholder="Enter text" aria-activedescendant="">
+<input aria-autocomplete="list" autocomplete="off" class="usa-input padding-right-3" type="text" aria-label="Auto Complete" id="autocomplete5" placeholder="Enter text" aria-activedescendant="">
 
 
 <ul aria-live="polite" aria-relevant="additions" class="usa-list usa-list--unstyled sds-autocomplete-selected" role="listbox" aria-label="Autocomplete 5 results">

--- a/src/components/03-components/04-tags/tags--chip.njk
+++ b/src/components/03-components/04-tags/tags--chip.njk
@@ -1,17 +1,53 @@
+<h2>Chips</h2>
 <span class="{{ label.classes }}">Normal</span>
 
- <span class="sds-tag sds-tag--chip">
+<span class="sds-tag sds-tag--chip">
   Normal with close icon
   <button class="sds-tag__close">
     <span class="fas fa-times" aria-hidden="true"></span>
   </button>
 </span>
 <div class="width-10">
-  
- <span class="sds-tag sds-tag--chip">
+
+  <span class="sds-tag sds-tag--chip">
   Wrapping with close icon
   <button class="sds-tag__close">
-    <span class="fas fa-times" aria-hidden="true"></span>
-  </button>
-</span>
+      <span class="fas fa-times" aria-hidden="true"></span>
+    </button>
+  </span>
 </div>
+
+<h2>Input Chips</h2>
+
+<input aria-autocomplete="list" autocomplete="off" class="usa-input padding-right-3 margin-y-1" type="text" aria-label="Auto Complete" id="autocomplete5" placeholder="Enter text" aria-activedescendant="">
+
+
+<ul aria-live="polite" aria-relevant="additions" class="usa-list usa-list--unstyled sds-autocomplete-selected" role="listbox" aria-label="Autocomplete 5 results">
+  <li role="option">
+    <div class="sds-tag sds-tag--chip sds-tag--input">
+      <div class="sds--tag__item">
+        <div>Level 1</div>
+        <div>id 1</div>
+      </div>
+      <button class="sds-tag__close">
+        <span class="fas fa-times" aria-hidden="true"></span>
+      </button>
+    </div>
+  </li>
+  <li role="option">
+    <div class="sds-tag sds-tag--chip sds-tag--input">
+      <div class="sds--tag__item">
+        <div>Level 2</div>
+        <div>id 2</div>
+      </div>
+    </div>
+  </li>
+  <li role="option">
+    <div class="sds-tag sds-tag--chip sds-tag--input sds-tag--disabled">
+      <div class="sds--tag__item">
+        <div>Level 2</div>
+        <div>id 2</div>
+      </div>
+    </div>
+  </li>
+</ul>

--- a/src/stylesheets/elements/_tags.scss
+++ b/src/stylesheets/elements/_tags.scss
@@ -29,7 +29,7 @@
   padding: 2px 5px;
   @include u-display('inline-flex');
   @include u-align-items("align-start");
-  margin-bottom: 5px;
+  @include u-margin-top('05');
 }
 
 .sds-tag.sds-tag--chip .sds-tag__close {
@@ -38,6 +38,10 @@
   margin-left: 5px;
   @include u-text('ink');
   cursor: pointer;
+
+  &:hover {
+    @include u-text('base');
+  }
 }
 
 // Chip tag input

--- a/src/stylesheets/elements/_tags.scss
+++ b/src/stylesheets/elements/_tags.scss
@@ -36,6 +36,27 @@
   @include button-unstyled;
   font-size: 12px;
   margin-left: 5px;
+  @include u-text('ink');
+}
+
+// Chip tag input
+.sds-tag.sds-tag--input {
+  max-width: units($theme-input-max-width);
+  @include u-width('full');
+  @include u-position('relative');
+
+  .sds--tag__item {
+    div:first-child, .sds-tag__primary-text {
+      @include u-text('semibold');
+    }
+  }
+
+  .sds-tag__close {
+    @include u-position('absolute');
+    @include u-top('05');
+    @include u-right('05');
+    cursor: pointer;
+  }
 }
 
 // Status tag

--- a/src/stylesheets/elements/_tags.scss
+++ b/src/stylesheets/elements/_tags.scss
@@ -37,6 +37,7 @@
   font-size: 12px;
   margin-left: 5px;
   @include u-text('ink');
+  cursor: pointer;
 }
 
 // Chip tag input
@@ -55,7 +56,6 @@
     @include u-position('absolute');
     @include u-top('05');
     @include u-right('05');
-    cursor: pointer;
   }
 }
 


### PR DESCRIPTION
This was done to avoid using autocomplete item classes on a chip element.