### PR TITLE
Re-enabled standard margin class utitlities

### DIFF
--- a/src/stylesheets/theme/_sds-theme-utilities.scss
+++ b/src/stylesheets/theme/_sds-theme-utilities.scss
@@ -75,4 +75,4 @@ $min-width-manual-values: (
   'menu': 200px
 );
 
-$margin-palettes: ('palette-units-em');
+$margin-palettes: ('palette-units-em','palette-margin-default');


### PR DESCRIPTION
There are two options now when using margin utitlities : for example margin-2 and margin-2em are equivalent