### PR TITLE
enhancement(table): updated styling for sds-table

### DIFF
--- a/src/components/03-components/table/table--subsections.njk
+++ b/src/components/03-components/table/table--subsections.njk
@@ -1,14 +1,13 @@
 {% extends "@table" %}
 
-
 {% block data %}
 	{%- for section in body.sections -%}
-		<tbody>
-			<tr class="sds-table__subsection-title">
+		<tbody class="sds-table__subsection">
+			<tr class="sds-table__row">
 				<th colspan="{{body.keys | length}}" scope="colgroup">{{section.title}}</th>
 			</tr>
 			{%- for data in section.data -%}
-				<tr>
+				<tr class="sds-table__row">
 					{%- for key in body.keys -%}
 						{%- if key.heading %}
 							{%- set key = key.value %}

--- a/src/components/03-components/table/table.njk
+++ b/src/components/03-components/table/table.njk
@@ -12,43 +12,44 @@
       title (string): section title
       data (array<object>): array of data objects with listed keys
 #}
+<div class="sds-table__container
+  {%- if modifiers -%}
+    {%- for modifier in modifiers %} sds-table__container--{{modifier}}{% endfor -%}
+  {%- endif -%}"
+>
+  <table class="sds-table">
 
-<table class="sds-table
-{%- if modifiers -%}
-  {%- for modifier in modifiers %} sds-table--{{modifier}}{%- endfor -%}
-{%- endif -%}
-">
+    {%- if title %}
+      <caption>{{title}}</caption>
+    {% endif -%}
 
-  {%- if title %}
-    <caption>{{title}}</caption>
-  {% endif -%}
+    {% if head %}
+      <thead>
+        <tr class="sds-table__row">
+          {%- for header in head.headers -%}
+            <th scope="col">{{header}}</th>
+          {% endfor -%}
+        </tr>
+      </thead>
+    {%- endif -%}
 
-  {% if head %}
-    <thead class="sds-table__head">
-      <tr>
-        {%- for header in head.headers -%}
-          <th scope="col">{{header}}</th>
-        {% endfor -%}
-      </tr>
-    </thead>
-  {%- endif -%}
-
-  {%- if body -%}
-    {%- block data %}
-      <tbody>
-        {%- for row in body.data -%}
-          <tr>
-            {%- for key in body.keys %}
-              {%- if key.heading %}
-                {%- set key = key.value %}
-                <th scope="row">{{ row[key] }}</th>
-              {%- else %}
-                <td>{{row[key]}}</td>
-              {%- endif -%}
-            {%- endfor -%}
-          </tr>
-        {%- endfor -%}
-      </tbody>
-    {% endblock -%}
-  {%- endif -%}
-</table>
+    {%- if body -%}
+      {%- block data %}
+        <tbody>
+          {%- for row in body.data -%}
+            <tr class="sds-table__row">
+              {%- for key in body.keys %}
+                {%- if key.heading %}
+                  {%- set key = key.value %}
+                  <th scope="row">{{ row[key] }}</th>
+                {%- else %}
+                  <td>{{row[key]}}</td>
+                {%- endif -%}
+              {%- endfor -%}
+            </tr>
+          {%- endfor -%}
+        </tbody>
+      {% endblock -%}
+    {%- endif -%}
+  </table>
+</div>

--- a/src/stylesheets/components/_table.scss
+++ b/src/stylesheets/components/_table.scss
@@ -1,42 +1,114 @@
 $sds-table-border: "1px";
 
+%sds-table--highlight {
+  @include u-text('semibold');
+  @include u-bg('accent-cool-lighter');
+  @include u-border-top('base-light', $sds-table-border);
+}
+
+%sds-table--cell {
+  @include u-padding-y(1);
+  @include u-padding-x(2);
+  color: inherit;
+  font-size: inherit;
+  border: 0;
+}
+
 .sds-table {
   @extend .usa-table;
-  @include u-border('base-light', $sds-table-border);
-  td, th {
-    border: 0;
-  }
-  tbody {
-    // tiger stripes for tables without subsections
-    :first-child:not(.sds-table__subsection-title) ~ :nth-of-type(even) {
-      & > * {
-        @include u-bg("base-lightest");
-      }
-    }
-    &:not(:first-of-type) {
-      @include u-border-top('base-light', $sds-table-border);
-    }
-  }
-  &--borderless {
-    border: 0;
-  }
-  &__head {
-    @include u-border-bottom('base-light', $sds-table-border);
+  width: 100%;
+  border-collapse: separate;
+  margin: 0;
+
+  thead {
     th {
+      @extend %sds-table--cell;
+      @include u-border-bottom('base-light', $sds-table-border);
       @include u-text('semibold');
       @include u-bg("base-lighter");
     }
   }
-  &__subsection-title {
-    th {
-      @include u-text('semibold');
-      @include u-bg('accent-cool-lighter');
+
+  tbody {
+    th, td {
+      @extend %sds-table--cell;
     }
-    // tiger stripes for subsections
-    & ~ :nth-of-type(odd) {
-      & > * {
+
+    // tiger stripes for tables without subsections or expandable rows
+    &:only-of-type:not(.sds-table--expansion) {
+      .sds-table__row:nth-of-type(even) > td {
         @include u-bg("base-lightest");
       }
     }
+  }
+
+  // sticky column border
+  .sds-table__heading--sticky:first-child, .sds-table__cell--sticky:first-child {
+    @include u-border-right('base-light', $sds-table-border);
+  }
+
+  &__subsection {
+    tr:first-child > th {
+      @extend %sds-table--highlight;
+    }
+    // tiger stripes for subsections
+    tr:nth-of-type(odd) {
+      td {
+        @include u-bg("base-lightest");
+      }
+    }
+    // remove double border with thead bottom border
+    &:first-of-type > tr > th {
+      border-top: 0;
+    }
+  }
+
+  // expansion tables
+  &--expansion {
+    // tiger stripes for expansion tables
+    .sds-table__row:nth-child(4n + 3):not(.sds-table__row--expanded) {
+      td {
+        @include u-bg("base-lightest");
+      }
+    }
+
+    // detail row parent when expanded
+    .sds-table__row--expanded {
+      td {
+        @extend %sds-table--highlight;
+      }
+      // remove double border with thead bottom border
+      &:first-of-type > td {
+        border-top: 0;
+      }
+      // detail row when expanded
+      + .sds-table__row--detail {
+        display: table-row;
+      }
+    }
+
+    // detail row when collapsed
+    .sds-table__row--detail {
+      display: none;
+      .sds-table__cell--detail {
+        @include u-border-bottom('base-light', $sds-table-border);
+      }
+    }
+  }
+
+  .sds-button.usa-button--unstyled {
+    color: inherit;
+    padding: 0;
+    background: inherit;
+  }
+}
+
+.sds-table__container {
+  @include u-border('base-light', $sds-table-border);
+  height: inherit;
+  max-height: inherit;
+  overflow: auto;
+  &--borderless {
+    border: 0;
   }
 }


### PR DESCRIPTION
#### Breaking Changes/Updates: ####
- table border no longer set by table itself - instead wrap table in div with class `sds-table__container` shown below

#### Added: ####
- add div wrapping table with class `sds-table__container`
  -  adds table border (unless modified with `sds-table__container--borderless`)
  - inherits height of parent element
  - sets scroll for x and y overflow
- add `sds-table__row` class to all `tr` elements
  - adds striping for table cells
- add `sds-table__subsection` class to all `tbody` elements of tables with multiple sections

#### Depreciated classes: ####
- `sds-table__head`
- `sds-table__subsection-title`

Checked in Firefox, Chrome, Safari, IE, and Edge
508 Testing using Wave and AMP