### PR TITLE
Add styling for hidden header logo

### DIFF
--- a/src/stylesheets/components/_navbar.scss
+++ b/src/stylesheets/components/_navbar.scss
@@ -9,9 +9,18 @@
   @include grid-container($theme-header-max-width);
 }
 .sds-navbar__title{
-  
   @include u-font('heading','md') ;
   @include u-text('semibold') ;
- 
+}
 
+.sds-navbar-blank {
+  min-height: 3rem;
+}
+
+.sds-nav__secondary-blank {
+  bottom: 3rem;
+}
+
+.usa-navbar {
+  justify-content: flex-end;
 }

--- a/src/stylesheets/components/_navbar.scss
+++ b/src/stylesheets/components/_navbar.scss
@@ -13,11 +13,11 @@
   @include u-text('semibold') ;
 }
 
-.sds-navbar-blank {
+.sds-navbar--blank {
   min-height: 3rem;
 }
 
-.sds-nav__secondary-blank {
+.sds-nav__secondary--blank {
   bottom: 3rem;
 }
 


### PR DESCRIPTION
Adds styling for when header logo is hidden. A min height is applied to account for spacing to take up header when logo is hidden, adjust margin of header submenus, and ensure the hamburger menu is right aligned on mobile view when logo is not present.