### PR TITLE
IAE-43474 CSS adjustment

### DIFF
--- a/src/stylesheets/components/_dialog.scss
+++ b/src/stylesheets/components/_dialog.scss
@@ -29,6 +29,11 @@
   max-height: 65vh;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
+  .text-base{
+    p {
+      max-width: none;
+    }
+  }
 }
 
 .sds-dialog-actions {

--- a/src/stylesheets/components/_dialog.scss
+++ b/src/stylesheets/components/_dialog.scss
@@ -29,9 +29,9 @@
   max-height: 65vh;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
-  .text-base{
+  .sds-dialog-content--centered{
     p {
-      max-width: none;
+      margin: auto;
     }
   }
 }


### PR DESCRIPTION
https://cm-jira.usa.gov/browse/IAE-43474

![Screen Shot 2020-11-17 at 11 17 23 AM](https://user-images.githubusercontent.com/7127587/99416409-ce04f880-28c6-11eb-8b37-08933931feb2.png)

fixes this issue where text-align isn't center

after:

![Screen Shot 2020-11-17 at 11 20 52 AM](https://user-images.githubusercontent.com/7127587/99416582-fee52d80-28c6-11eb-8307-5f911eee6b13.png)
