### PR TITLE
Remove fixed width from alert header

### DIFF
--- a/src/stylesheets/components/_alert.scss
+++ b/src/stylesheets/components/_alert.scss
@@ -155,7 +155,6 @@
     @include u-border-y(1px);
     @include u-border-y('yellow-20v');
     @include u-padding('105');
-    min-width: 375px;
 
     .sds-alert--header__icon {
       @include u-margin-x('205');


### PR DESCRIPTION
The min-width would cause the alert to go out of page bounds in mobile mode.