### PR TITLE
Fix(settings): Allow override of root font

### DIFF
--- a/src/stylesheets/theme/_sds-theme-typography.scss
+++ b/src/stylesheets/theme/_sds-theme-typography.scss
@@ -35,7 +35,7 @@ Accepts true or false
 ----------------------------------------
 */
 
-$theme-respect-user-font-size: true;
+$theme-respect-user-font-size: true !default;
 
 // $theme-root-font-size only applies when
 // $theme-respect-user-font-size is set to


### PR DESCRIPTION
 ###  Allow override of root font.
This is needed for sites that have set the root font to a specific pixel size and need components to be calculated using this font pixel size instead of the default 100%