### PR TITLE
IAE-44731 Update to show scrollbar if needed on Mac

### DIFF
--- a/src/stylesheets/components/_dialog.scss
+++ b/src/stylesheets/components/_dialog.scss
@@ -8,8 +8,19 @@
   width: 100%;
   height: 100%;
   min-height: inherit;
-  max-height: inherit;
+  max-height: 90vh;
   position: relative;
+
+  ::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 7px;
+  }
+  
+  ::-webkit-scrollbar-thumb {
+    border-radius: 4px;
+    background-color: rgba(0, 0, 0, .5);
+    box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+  }
 }
 
 .sds-dialog__container {


### PR DESCRIPTION
By default, mac does not show scrollbar unless the user is actively scrolling. With this update, if there is content that can be scrolled into view, the scrollbar is displayed at all times. The scrollbar will be shown even if the user is not actively scrolling