### PR TITLE
Add text-align-end style for checkboxes

### DIFF
--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -92,3 +92,7 @@
     background-position: center center;
     background-size: .75rem auto;
 }
+
+.usa-checkbox.text-align-end{
+  text-align: end;
+}


### PR DESCRIPTION
Added to ensure "Show Inactive Filter Values" checkbox is right aligned on More Filters dialog