### PR TITLE
IAE-45479: Add position on checkbox in Firefox to prevent double scrollbar

### DIFF
--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -96,3 +96,9 @@
 .usa-checkbox.text-align-end{
   text-align: end;
 }
+
+@-moz-document url-prefix() {
+  .usa-checkbox{
+    position: relative;
+  }
+}

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -98,7 +98,7 @@
 }
 
 @-moz-document url-prefix() {
-  .usa-checkbox{
+  .usa-checkbox, .usa-fieldset{
     position: relative;
   }
 }


### PR DESCRIPTION
Addresses https://github.com/GSA/sam-design-system/issues/467.

USWDS hides browser input by applying ` {
    position: absolute;
    left: -999em;
}` to push the input far to the left. 

sds-dialog-container has a position defined, this position is inherited by its non-positioned descendants on all browsers except Firefox. Per [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/position#absolute), "It [an element with position:absolute] is positioned relative to its closest positioned ancestor, if any; otherwise, it is placed relative to the initial containing block." As a result of that behavior and the lack of the position being inherited by descendants on Firefox, the inputs try and position themselves relative to their closest positioned ancestor, resulting in the double scrollbar

<img width="876" alt="Screen Shot 2021-01-06 at 12 04 31 PM" src="https://user-images.githubusercontent.com/72805180/103798269-76a61d80-5017-11eb-8f64-5d8443d29a07.png">
