### PR TITLE
Add case to fix double scrollbar in IE11

### DIFF
--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -97,8 +97,16 @@
   text-align: end;
 }
 
+//IAE-45479 fix in FF
 @-moz-document url-prefix() {
   .usa-checkbox, .usa-fieldset{
+    position: relative;
+  }
+}
+
+//IAE-45479 fix in IE11
+@media all and (-ms-high-contrast:none) {
+  *::-ms-backdrop, .usa-checkbox, .usa-fieldset{
     position: relative;
   }
 }


### PR DESCRIPTION
Have confirmed this fixes the noted issue by using developer tools in IE to apply the styles contained in PR and issue no longer presented.