### PR TITLE
Remove overflow auto in system alerts container

### DIFF
--- a/src/stylesheets/components/_alert.scss
+++ b/src/stylesheets/components/_alert.scss
@@ -160,7 +160,6 @@
         @include grid-container($theme-header-max-width);
         display: block;
         height: auto;
-        overflow: auto;
       }
     }
 


### PR DESCRIPTION
The alerts container was originally added simply to align with rest of the header items - Removes overflow auto styling to prevent unnecessary scrolling in IE