### PR TITLE
center login modal fix

### DIFF
--- a/src/stylesheets/components/_dialog.scss
+++ b/src/stylesheets/components/_dialog.scss
@@ -38,11 +38,12 @@
     max-height: 65vh;
     overflow: auto;
     line-height: 20px;
-    -webkit-overflow-scrolling: touch;
-    .sds-dialog-content--centered {
-        p {
-            margin: auto;
-        }
+    -webkit-overflow-scrolling: touch;   
+}
+
+.sds-dialog-content.sds-dialog-content--centered {
+    p {
+        margin: auto;
     }
 }
 


### PR DESCRIPTION
![Screen Shot 2021-01-26 at 11 08 58 AM](https://user-images.githubusercontent.com/7127587/105871102-f7c55480-5fc6-11eb-9c43-6eba0d9d7fb6.png)

Fixing the above issue where paragraph text in dialog content wasn't getting centered