### PR TITLE
IAE-47383: Remove double divider on result-list

### DIFF
--- a/src/components/01-branding/02-typography/fields/fields--example.njk
+++ b/src/components/01-branding/02-typography/fields/fields--example.njk
@@ -66,7 +66,7 @@
 </div>
 
 <div class="sections">
-    <div class="sds-result-item">
+    <div class="sds-result-item sds-result-item__divided">
         <div class="grid-row grid-gap">
             <div class="grid-col-12">
                 <div class="sds-group">
@@ -176,7 +176,7 @@
 
 <hr>
 <p>Result list example<p>
-        <div class="sds-result-item">
+        <div class="sds-result-item sds-result-item__divided">
             <div class="grid-row grid-gap">
                 <div class="grid-col">
                     <h3 class="font-sans-xs margin-y-0">

--- a/src/components/05-patterns/01-pages/pages--display-page.njk
+++ b/src/components/05-patterns/01-pages/pages--display-page.njk
@@ -335,7 +335,7 @@
           </div>
         </div>
         {# page content #}
-        <div class="sds-result-item">
+        <div class="sds-result-item sds-result-item__divided">
           <div class="grid-row">
             <div class="tablet:grid-col-fill grid-row">
               <div class="sds-tile--outline">
@@ -407,7 +407,7 @@
           <div class="sds-result-item__square"></div>
           <h2>BUSINESS INFORMATION</h2>
         </div>
-        <div class="sds-result-item">
+        <div class="sds-result-item sds-result-item__divided">
           <div class="grid-row">
             <div class="grid-col-6 tablet:grid-col sds-field">
               <span class="sds-field--large">Doing Business As</span>
@@ -442,7 +442,7 @@
         <div class="sds-result-item__title grid-row">
           <h3>Registration Dates</h3>
         </div>
-        <div class="sds-result-item">
+        <div class="sds-result-item sds-result-item__divided">
           <div class="grid-row">
             <div class="grid-col-6 tablet:grid-col sds-field">
               <span class="sds-field--large">Activation Date</span>
@@ -461,7 +461,7 @@
         <div class="sds-result-item__title grid-row">
           <h3>Entity Dates</h3>
         </div>
-        <div class="sds-result-item">
+        <div class="sds-result-item sds-result-item__divided">
           <div class="grid-row">
             <div class="grid-col-6 tablet:grid-col-4 sds-field">
               <span class="sds-field--large">Entity Start Date</span>
@@ -476,7 +476,7 @@
         <div class="sds-result-item__title grid-row">
           <h3>Immediate Owner</h3>
         </div>
-        <div class="sds-result-item">
+        <div class="sds-result-item sds-result-item__divided">
           <div class="grid-row">
             <div class="grid-col-6 tablet:grid-col-4 sds-field">
               <span class="sds-field--large">CAGE</span>
@@ -491,7 +491,7 @@
         <div class="sds-result-item__title grid-row">
           <h3>Executive Compensation</h3>
         </div>
-        <div class="sds-result-item">
+        <div class="sds-result-item sds-result-item__divided">
           <div class="grid-row">
             <p>Registrants in the System for Award Management (SAM) respond to the Executive Compensation questions in accordance with Section 6202 of P.L. 110-252, amending the Federal Funding Accountability and Transparency Act (P.L. 109-282). This information
               is not displayed in SAM. It is sent to USAspending.gov for display in association with an eligible award. Maintaining an active registration in SAM demonstrates the registrant responded to the questions.</p>
@@ -505,7 +505,7 @@
         <div class="sds-result-item__title grid-row">
           <h3>Business Types</h3>
         </div>
-        <div class="sds-result-item">
+        <div class="sds-result-item sds-result-item__divided">
           <div class="grid-row">
             <div class="grid-col-6 tablet:grid-col-4 sds-field">
               <span class="sds-field--large">Entity Structure</span>
@@ -528,7 +528,7 @@
         <div class="sds-result-item__title grid-row">
           <h3>Government Types</h3>
         </div>
-        <div class="sds-result-item">
+        <div class="sds-result-item sds-result-item__divided">
           <div class="grid-row">
             <div class="grid-col-6 tablet:grid-col-4 sds-field">
               <span class="sds-field--large">CAGE</span>
@@ -543,7 +543,7 @@
         <div class="sds-result-item__title grid-row">
           <h3>Other Entity Qualifiers</h3>
         </div>
-        <div class="sds-result-item">
+        <div class="sds-result-item sds-result-item__divided">
           <div class="grid-row">
             <p>Educational Institution, State Controlled, Institution of Higher Learning</p>
           </div>
@@ -553,7 +553,7 @@
           <div class="sds-result-item__square"></div>
           <h2>FINANCIAL INFORMATION</h2>
         </div>
-        <div class="sds-result-item">
+        <div class="sds-result-item sds-result-item__divided">
           <div class="grid-row">
             <div class="grid-col-6 tablet:grid-col-4 sds-field">
               <span class="sds-field--large">Accepts Credit Card Payments</span>
@@ -573,7 +573,7 @@
         <div class="sds-result-item__title grid-row">
           <h3>Electronic Business</h3>
         </div>
-        <div class="sds-result-item">
+        <div class="sds-result-item sds-result-item__divided">
           <div class="sds-card border-width-0">
             <div class="sds-card__header sds-card__header--left">
               <h2 class="sds-card__title">James McStay</h2>
@@ -603,7 +603,7 @@
         <div class="sds-result-item__title grid-row">
           <h3>Government Business</h3>
         </div>
-        <div class="sds-result-item">
+        <div class="sds-result-item sds-result-item__divided">
           <h4>Primary Contact</h4>
           <div class="sds-card border-width-0">
             <div class="sds-card__header sds-card__header--left">
@@ -660,7 +660,7 @@
         <div class="sds-result-item__title grid-row">
           <h3>Past Performace</h3>
         </div>
-        <div class="sds-result-item">
+        <div class="sds-result-item sds-result-item__divided">
           <div class="sds-card border-width-0">
             <div class="sds-card__header sds-card__header--left">
               <h2 class="sds-card__title">James McStay</h2>

--- a/src/stylesheets/components/_results.scss
+++ b/src/stylesheets/components/_results.scss
@@ -2,10 +2,12 @@
   @include u-margin-top(1);
   @include u-margin-bottom('205');
   @include u-padding('105');
-  @include u-border-top('05');
-  @include u-border-x(0);
-  @include u-border-bottom(0);
-  @include u-border('base-lighter');
+  &.sds-result-item__divided{
+    @include u-border-top('05');
+    @include u-border-x(0);
+    @include u-border-bottom(0);
+    @include u-border('base-lighter');
+  }
 
   .action-menu {
     @include u-height('full');


### PR DESCRIPTION
Both sam-styles and sam-design-system are trying to provide dividers on result list resulting in two dividers being shown. Given the logic in result-list to toggle dividers and the lack of connection between where this toggle is and where the `sds-result-item` style is applied I am moving the style which adds the divider to a separate class which can still be applied as needed if only using sam-styles, but will not result in a double divider in SDS.