### PR TITLE
IAE-47071: Updating text and border darkness

### DIFF
--- a/src/stylesheets/elements/_tags.scss
+++ b/src/stylesheets/elements/_tags.scss
@@ -377,8 +377,8 @@ Label Title
 
 .label-upcoming {
   @extend .roadmap-label;
-  @include u-text("base-light");
-  @include u-border("base-light");
+  @include u-text("base");
+  @include u-border("base");
   border-width: 1px;
   border-style: solid;
   background-color: transparent;


### PR DESCRIPTION
Updating the color of upcoming tag's text and border to ensure enough contrast based on feedback during Friday's demo.