### PR TITLE
Sds-dialog--full class should take full use of user's screen

### DIFF
--- a/src/stylesheets/components/_dialog.scss
+++ b/src/stylesheets/components/_dialog.scss
@@ -142,6 +142,7 @@
 .sds-dialog--full {
     .sds-dialog__container {
         @extend .sds-dialog__container;
+        height: 100vh;
         padding: 0;
     }
 }


### PR DESCRIPTION
Sds-dialog--full class uses 100vh