### PR TITLE
Update button-group items to take up full height

### DIFF
--- a/src/stylesheets/components/_buttongroup.scss
+++ b/src/stylesheets/components/_buttongroup.scss
@@ -30,6 +30,7 @@
       @include u-border('secondary-dark');
       @include u-bg('secondary-dark');
       @include u-text('white');
+      height: 100%;
     }
 
     .usa-button.usa-button--outline {


### PR DESCRIPTION
Fixes issue noted in demo where if some buttons expand to multiple rows, the one that did not expand would have a different height.