### PR TITLE
IAE-48851

### DIFF
--- a/src/components/01-branding/icons/icon/icon.njk
+++ b/src/components/01-branding/icons/icon/icon.njk
@@ -1,6 +1,6 @@
 {# <p><b>To be deprecated</b></p> #}
 {%- set prefix = prefix or "sds" -%}
-<i class="{{prefix}} fa-{{icon}}{% if classes %} {{classes}}{% endif %}"{% if title %}aria-hidden="true" title="{{title}}"{% endif %}{% if dataTransform %} data-fa-transform="{{dataTransform}}"{% endif %}></i>
+<i class="{{prefix}} text-ink fa-{{icon}}{% if classes %} {{classes}}{% endif %}"{% if title %}aria-hidden="true" title="{{title}}"{% endif %}{% if dataTransform %} data-fa-transform="{{dataTransform}}"{% endif %}></i>
 
 {%- if title %}
   <span class="sr-only">{{title}}</span>

--- a/src/stylesheets/components/_header.scss
+++ b/src/stylesheets/components/_header.scss
@@ -11,9 +11,10 @@
 .usa-menu-btn {
   @include button-unstyled;
 
-  .fa-layers-counter {
-    @include u-top('neg-1px');
-    @include u-right(2px);
+  .counter-icon{
+    color: red !important;
+    margin-top: -2.4em;
+    margin-left: 2.4em;
   }
 }
 

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -65,8 +65,10 @@
 
 .usa-nav__secondary-links {
   .usa-nav__secondary-item {
-    svg {
-      color: color('black');
+    .counter-icon{
+      color: red;
+      margin-top: -1rem;
+      margin-right: -1.1rem;
     }
     @include at-media($theme-header-min-width) {
       padding-left: units(3);

--- a/src/stylesheets/components/_navigation.scss
+++ b/src/stylesheets/components/_navigation.scss
@@ -67,8 +67,8 @@
   .usa-nav__secondary-item {
     .counter-icon{
       color: red;
-      margin-top: -1rem;
-      margin-right: -1.1rem;
+      margin-top: -1.7em;
+      margin-right: -1.5em;
     }
     @include at-media($theme-header-min-width) {
       padding-left: units(3);


### PR DESCRIPTION
Updated navigation to not apply black coloring to all icons. This was preventing a color from being applied to sds-icon via use of a style. Instead all icons which need to be colored black will have class `text-ink` applied.

This change will enable the header icon which has a red dot offset on top of it.