### PR TITLE
Fix dialog exit icon alignment

### DIFF
--- a/src/stylesheets/components/_dialog.scss
+++ b/src/stylesheets/components/_dialog.scss
@@ -62,7 +62,7 @@
         position: absolute;
         right: 20px;
         top: 15px;
-        width: 15px;
+        width: 20px;
         height: 20px;
         text-align: center;
         color: #9b9b9b;


### PR DESCRIPTION
A couple aligment issues were reported after updating to the latest SDS version. This PR addresses one of them, the other is fixed in sam-design-system

Before
<img width="434" alt="Screen Shot 2021-04-07 at 11 50 20 AM" src="https://user-images.githubusercontent.com/72805180/113897093-8e1cb000-9798-11eb-92d4-d8ef9da44fa3.png">
After
<img width="434" alt="Screen Shot 2021-04-07 at 11 50 50 AM" src="https://user-images.githubusercontent.com/72805180/113897096-8eb54680-9798-11eb-98b9-1f50589c03ae.png">
