### PR TITLE
Move css for sidenav component into sidenav file

### DIFF
--- a/src/stylesheets/components/_sidenav.scss
+++ b/src/stylesheets/components/_sidenav.scss
@@ -14,7 +14,7 @@
   }
 
   .usa-current {
-
+    
     @include add-bar($theme-sidenav-current-border-width, "secondary-darker", "left", 0, 0, 0);
     color: color("secondary-darker");
     font-weight: font-weight("semibold");
@@ -23,6 +23,30 @@
       @include u-display("block");
       padding: units(1) 0 units(1) units(2);
       cursor: pointer;
+    }
+  }
+
+
+  .usa-sidenav__sublist .usa-current::after {
+    background-color: transparent;
+    border-radius: 0;
+    content: "";
+    display: block;
+    position: absolute;
+    bottom: 0;
+    top: 0;
+    width: 0.25rem;
+    left: 0;
+  }
+
+  .usa-sidenav__sublist .usa-current span {
+    background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAASCAYAAABit09LAAAABHNCSVQICAgIfAhkiAAAAWRJREFUKJFt0bFrFEEUx/Hvb4b7A5QUgRRBCyFNiiR3cGcp/gMWV0gIaWxsTGETSHGVKdKkCClShViIgqDNFddZyO4OC16TVsxhwN7q9tx5FsawN7np3o8P8+a9UZZlG865M2AJ2Ot0Op8lGclx3vtzYBNYBT6UZfnEzNwdGGN80KhbdV2/L8tyy8w0ByV9aQaS7scY3xVFsZbeeAhcJZ0eOufOiqK47ea63e5XSQfAr6Y0s8eS3oQQlgF0EyqE8BrYB+4ltx9VVXXobt5l3vtj4DydFthrtVo7c5ONx+OV6XT6cwH+MbevqqrqBQgzwyXBzgL3Bzi+hSGEZ8DLVEk6nc1mFwLI8/yppBPgUdLhY4zxVa/Xu1ae55uS3gJrCSq898/b7fZ3+PeFBykCrmKML/4jAAesJ+i3mW2PRqPLZugkfWvUtaTdyWSSDQaDOAdjjPtmlgHXZrY9HA4/9fv9O/v8Cz0+lHP+xemeAAAAAElFTkSuQmCC');
+    background-repeat: no-repeat;
+    margin-left: -1.1rem;
+    padding-left: 1.1rem;
+  
+    .usa-sidenav a{
+      @include u-padding-y(0);
     }
   }
 
@@ -53,7 +77,5 @@
       }
 
     }
-
-
   }
 }

--- a/src/stylesheets/components/_toolbar.scss
+++ b/src/stylesheets/components/_toolbar.scss
@@ -20,29 +20,6 @@
     color: color("ink");
   }
 
-
-  .sds-toolbar .usa-sidenav .usa-sidenav__sublist .usa-current::after {
-    background-color: transparent;
-    border-radius: 0;
-    content: "";
-    display: block;
-    position: absolute;
-    bottom: 0;
-    top: 0;
-    width: 0.25rem;
-    left: 0;
-  }
-  .sds-toolbar .usa-sidenav .usa-sidenav__sublist .usa-current span {
-    background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAASCAYAAABit09LAAAABHNCSVQICAgIfAhkiAAAAWRJREFUKJFt0bFrFEEUx/Hvb4b7A5QUgRRBCyFNiiR3cGcp/gMWV0gIaWxsTGETSHGVKdKkCClShViIgqDNFddZyO4OC16TVsxhwN7q9tx5FsawN7np3o8P8+a9UZZlG865M2AJ2Ot0Op8lGclx3vtzYBNYBT6UZfnEzNwdGGN80KhbdV2/L8tyy8w0ByV9aQaS7scY3xVFsZbeeAhcJZ0eOufOiqK47ea63e5XSQfAr6Y0s8eS3oQQlgF0EyqE8BrYB+4ltx9VVXXobt5l3vtj4DydFthrtVo7c5ONx+OV6XT6cwH+MbevqqrqBQgzwyXBzgL3Bzi+hSGEZ8DLVEk6nc1mFwLI8/yppBPgUdLhY4zxVa/Xu1ae55uS3gJrCSq898/b7fZ3+PeFBykCrmKML/4jAAesJ+i3mW2PRqPLZugkfWvUtaTdyWSSDQaDOAdjjPtmlgHXZrY9HA4/9fv9O/v8Cz0+lHP+xemeAAAAAElFTkSuQmCC');
-    background-repeat: no-repeat;
-    margin-left: -1.1rem;
-    padding-left: 1.1rem;
-
-    .usa-sidenav a{
-      @include u-padding-y(0);
-    }
-  }
-
 .sds-toolbar + * {
   margin-left: 25px;
   transition: all 0.2s ease-out;


### PR DESCRIPTION
Currently, the side navigation css shows arrow icons on sublist items only if the sidenav itself is wrapped in a `sds-toolbar` class. This change seeks to remove the dependency on `sds-toolbar` in order to display arrow icon on selected sublist item, so that all side nav components, regardless of whether they're wrapped in `sds-toolbar` class or not displays the selected sublist nav item with an arrow next to it.