### PR TITLE
Add css for file-input

### DIFF
--- a/src/stylesheets/components/_fileinput.scss
+++ b/src/stylesheets/components/_fileinput.scss
@@ -1,0 +1,3 @@
+.has-invalid-file .usa-file-input__accepted-files-message {
+  color: color('error-dark');
+}

--- a/src/stylesheets/components/_index.scss
+++ b/src/stylesheets/components/_index.scss
@@ -38,3 +38,4 @@
 @import 'slideout';
 @import 'stepindicator';
 @import 'processlist';
+@import 'fileinput';


### PR DESCRIPTION
overrides uswds's style for invalid file type text message to use our error dark instead of secondary colors. Using secondary works for USWDS because their secondary color is red, however, ours is blue.
https://designsystem.digital.gov/components/file-input/