### PR TITLE
Update 508 issue with datepicker

### DIFF
--- a/src/stylesheets/components/_datepicker.scss
+++ b/src/stylesheets/components/_datepicker.scss
@@ -5,4 +5,14 @@
   td {
     background-color: color('base-lightest');
   }
+
+  .usa-date-picker__calendar__date--selected {
+    @include u-bg('primary-darker');
+    @include u-text('white');
+  }
+
+  .usa-date-picker__calendar__date--selected:focus {
+    @include u-bg('primary-darker');
+    @include u-text('white');
+  }
 }


### PR DESCRIPTION
Based off demo feedback:
The selected date picker background and text color was not 508 compliant in with sam-styles theme, so updated those colors to use primary-darker instead of primary. This gives the text and background enough needed contrast to pass 508 checks