### PR TITLE
Update sam-styles demo for icon buttons and tags

### DIFF
--- a/src/components/03-components/04-tags/tags.njk
+++ b/src/components/03-components/04-tags/tags.njk
@@ -7,6 +7,6 @@
 
 <h3 class="margin-bottom-1">Customize tag color</h3>
 <span class="usa-tag sds-tag--info-white sds-tag--outline--error bg-error-light">SAM</span>
-<span class="usa-tag sds-tag--info-white sds-tag--outline--green bg-secondary">SAM</span>
+<span class="usa-tag sds-tag--info-white sds-tag--outline--green bg-secondary text-white">SAM</span>
 <span class="usa-tag sds-tag--info-white sds-tag--outline--green bg-accent-warm">SAM</span>
 <span class="usa-tag sds-tag--info-white sds-tag--outline--warning-light bg-accent-cool-light">SAM</span>

--- a/src/stylesheets/elements/_buttons.scss
+++ b/src/stylesheets/elements/_buttons.scss
@@ -412,6 +412,7 @@
 .sds-button.sds-button--icon {
   width: auto;  
   height: fit-content;
+  line-height: 1.0;
   @include u-padding-x(4);
   @include u-radius("lg");
   @include u-display("flex");
@@ -427,6 +428,16 @@
     margin: auto 0;
     @include u-text("bold");
   }
+
+  &--selected,
+  &:hover {
+    @include u-border("secondary");
+    @include u-border-width("2px");
+  }
+
+  &:disabled {
+    @include button-disabled;
+  }
 }
 
 .sds-button--outline {
@@ -438,7 +449,7 @@
   width: fit-content;
 
   .sds-button--icon {
-    border: solid 1px color("primary");
+    border: solid 1px color("secondary");
     border-radius: radius($theme-button-border-radius);
     margin: auto;
   }
@@ -495,7 +506,13 @@
 
     &--selected,
     &:hover {
-      @include u-border('primary');
+      @include u-border('secondary');
+    }
+
+    &:disabled {
+      background-color: 'base-light';
+      color: color("white");
+      box-shadow: none;
     }
   }
 }


### PR DESCRIPTION
Update icon buttons based on wireframe:
<img width="1072" alt="Screen Shot 2021-10-20 at 3 48 28 PM" src="https://user-images.githubusercontent.com/73653244/138161783-6c1707ae-a5dd-49fd-9fe5-9fadc6b8293d.png">

Update demo for tags for 508 compliancy based on previous sprint demo feedback
