### PR TITLE
Directly refer to node_modules when importing uswds

### DIFF
--- a/src/stylesheets/sam.scss
+++ b/src/stylesheets/sam.scss
@@ -4,6 +4,6 @@
 *******************************/
 
 @import './theme/styles';
-@import '~uswds/dist/scss/uswds';
+@import 'node_modules/uswds/dist/scss/uswds';
 @import './elements/index';
 @import './components/index';


### PR DESCRIPTION
After upgrade to angular 12, references to uswds style library required going through node_modules specifically