### PR TITLE
Fix uswds peer dependecy to 2.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@gsa-sam/icons": "^1.0.0",
     "bootstrap-icons": "^1.2.1",
     "copy": "^0.3.2",
-    "uswds": "^2.11.2"
+    "uswds": "2.11.2"
   },
   "devDependencies": {
     "@babel/core": "^7.5.0",


### PR DESCRIPTION
Fix uswds dependency to 2.11.2. This prevents applications from auto upgrading to higher patch versions such as 2.13+