### PR TITLE
Reduce spacing of first filter inside accordion group wrappers

### DIFF
--- a/src/stylesheets/components/_accordion.scss
+++ b/src/stylesheets/components/_accordion.scss
@@ -121,6 +121,10 @@
     }
   }
 
+  .usa-accordion__content .usa-form-group:first-of-type {
+    margin-top: 0.5rem;
+  }
+
   .usa-accordion__button:not(.usa-banner__button) {
     background-color: inherit;
     @include u-padding-x(1);

--- a/src/stylesheets/components/_accordion.scss
+++ b/src/stylesheets/components/_accordion.scss
@@ -122,7 +122,7 @@
   }
 
   .usa-accordion__content .usa-form-group:first-of-type {
-    margin-top: 0.5rem;
+    @include u-margin-top(1);
   }
 
   .usa-accordion__button:not(.usa-banner__button) {


### PR DESCRIPTION
Margin between the first filter and accordion header is noticeably too large. Reduces margin of first filter 