### PR TITLE
Fix external link icon alignment

### DIFF
--- a/src/stylesheets/components/_externallink.scss
+++ b/src/stylesheets/components/_externallink.scss
@@ -1,7 +1,10 @@
 /************************************
    External link override USWDS image
 *************************************/
-.usa-link--external ::after {
-    background-position: 0% 60%;
-    background-image: url('#{$theme-image-path}/sam/box-arrow-up-right.svg');
+.usa-link--external {
+    display: inline;
+    &::after {
+        background-position: 0% 60%;
+        background-image: url('#{$theme-image-path}/sam/box-arrow-up-right.svg');
+    }
 }


### PR DESCRIPTION
Fixes #527.

Based on [instructions](https://github.com/uswds/uswds/pull/4277/files#diff-80bb9d0a39fce7fdec50121a312b458e11bd8f35ec02737223fa216594511b6bR14) hidden in USWDS PR/code I have added display:inline to external link so that icons are once again shown along side the link. The other styles that are mentioned there seem to make no change to the appearance of the icon so I have left them out.

Before:
<img width="243" alt="Screen Shot 2022-03-01 at 7 25 09 AM" src="https://user-images.githubusercontent.com/72805180/156168833-e6475a22-f93a-49a0-babc-1bd392b5ee45.png">
After:
<img width="243" alt="Screen Shot 2022-03-01 at 7 25 42 AM" src="https://user-images.githubusercontent.com/72805180/156168834-c0b26d6d-57a2-489b-a360-18383c6124c7.png">
