### PR TITLE
Add styling for usa-icon in search button

### DIFF
--- a/src/stylesheets/components/_search.scss
+++ b/src/stylesheets/components/_search.scss
@@ -16,6 +16,12 @@
     // @include u-minw(5);
     @include u-shadow(3);
     @include u-border(0);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    usa-icon{
+      color: white;
+    }
   }
 
   [type='search'] {


### PR DESCRIPTION
Search icon was no longer showing on button in search component. A SDS PR added a usa-icon to that button. This PR adds styling to center and color the new icon.

Before:
<img width="103" alt="Screen Shot 2022-03-30 at 6 27 50 AM" src="https://user-images.githubusercontent.com/72805180/160811989-4672fab5-31df-42bf-bd2a-400d6823b963.png">

After:
<img width="103" alt="Screen Shot 2022-03-30 at 6 24 11 AM" src="https://user-images.githubusercontent.com/72805180/160812033-35a7a3ac-3696-4af9-bcf4-a8de10ee0b63.png">

