### PR TITLE
Apply primary to radio and checkbox

### DIFF
--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -116,8 +116,8 @@
 }
 
 //checkbox
-.usa-checkbox__input[aria-checked="mixed"] + .usa-checkbox__label:before,
-.usa-checkbox__input[aria-checked="mixed"]:disabled + .usa-checkbox__label:before {
+.usa-checkbox__input[aria-checked="mixed"]+.usa-checkbox__label:before,
+.usa-checkbox__input[aria-checked="mixed"]:disabled+.usa-checkbox__label:before {
   @include u-bg("primary");
   box-shadow: 0 0 0 2px $theme-color-primary-darker;
   background-image: url("#{$theme-image-path}/minus-white.svg");
@@ -132,6 +132,7 @@
 
 //IAE-45479 fix in FF
 @-moz-document url-prefix() {
+
   .usa-checkbox,
   .usa-fieldset {
     position: relative;
@@ -140,6 +141,7 @@
 
 //IAE-45479 fix in IE11
 @media all and (-ms-high-contrast: none) {
+
   *::-ms-backdrop,
   .usa-checkbox,
   .usa-fieldset {
@@ -170,7 +172,25 @@
 
 .usa-checkbox,
 .usa-radio {
-  @include checkbox-and-radio-colors($selected-color: "primary-darker");
+
+  .usa-checkbox__input:checked+.usa-checkbox__label,
+  .usa-radio__input:checked+.usa-radio__label {
+    &::before {
+      background-color: #70e17b !important;
+    }
+  }
+
+  .usa-checkbox__input:checked+.usa-checkbox__label {
+    &::before {
+      box-shadow: 0 0 0 2px #70e17b !important;
+    }
+  }
+
+  .usa-radio__input:checked+.usa-radio__label {
+    &::before {
+      box-shadow: 0 0 0 2px #70e17b, inset 0 0 0 2px white !important;
+    }
+  }
 }
 
 .usa-radio {

--- a/src/stylesheets/elements/_inputs.scss
+++ b/src/stylesheets/elements/_inputs.scss
@@ -119,7 +119,7 @@
 .usa-checkbox__input[aria-checked="mixed"]+.usa-checkbox__label:before,
 .usa-checkbox__input[aria-checked="mixed"]:disabled+.usa-checkbox__label:before {
   @include u-bg("primary");
-  box-shadow: 0 0 0 2px $theme-color-primary-darker;
+  box-shadow: 0 0 0 2px $theme-color-primary;
   background-image: url("#{$theme-image-path}/minus-white.svg");
   background-repeat: no-repeat;
   background-position: center center;
@@ -176,19 +176,19 @@
   .usa-checkbox__input:checked+.usa-checkbox__label,
   .usa-radio__input:checked+.usa-radio__label {
     &::before {
-      background-color: #70e17b !important;
+      background-color: $theme-color-primary !important;
     }
   }
 
   .usa-checkbox__input:checked+.usa-checkbox__label {
     &::before {
-      box-shadow: 0 0 0 2px #70e17b !important;
+      box-shadow: 0 0 0 2px $theme-color-primary !important;
     }
   }
 
   .usa-radio__input:checked+.usa-radio__label {
     &::before {
-      box-shadow: 0 0 0 2px #70e17b, inset 0 0 0 2px white !important;
+      box-shadow: 0 0 0 2px $theme-color-primary, inset 0 0 0 2px white !important;
     }
   }
 }


### PR DESCRIPTION
Add styling to temporarily override mixin added in USWDS 2.13 so that radio and checkbox continue to be primary color. Attached are screenshots from my local to show how these controls look with this change applied. 


<img width="871" alt="Screen Shot 2022-05-04 at 2 05 18 PM" src="https://user-images.githubusercontent.com/72805180/166775096-783574cc-9433-4328-b6b3-8d79cb36adb9.png">
<img width="871" alt="Screen Shot 2022-05-04 at 2 05 24 PM" src="https://user-images.githubusercontent.com/72805180/166775119-60b36299-432b-427d-a8c2-c900a22ac63e.png">
