### PR TITLE
Remove hover & focus behavior to enable esc dismiss

### DIFF
--- a/src/stylesheets/components/_popup.scss
+++ b/src/stylesheets/components/_popup.scss
@@ -185,8 +185,7 @@
   cursor: pointer;
 }
 
-.sds-tooltip:hover .sds-tooltip__content,
-.sds-tooltip:focus .sds-tooltip__content,
+.sds-tooltip .tooltip-expanded.sds-tooltip__content,
 .sds-popover__content.sds-popover__hidden,
 .sds-popover__content.sds-popover__shown {
   display: block;


### PR DESCRIPTION
In order to allow esc key to hide content, focus pseudo-class needs to be removed from style def. .tooltip-expanded will instead be programmatically added and removed to facilitate showing tooltip content.