### PR TITLE
Add hover class for NGX-USWDS table

### DIFF
--- a/src/stylesheets/components/_table.scss
+++ b/src/stylesheets/components/_table.scss
@@ -125,7 +125,8 @@ $sds-table-border: "1px";
     background: inherit;
   }
 
-  tr.sds-table__row--hovered{
+  tr.sds-table__row--hovered,
+  tr.usa-table__row--hovered{
     td{
       @include u-bg('base-light', !important);
       cursor: pointer;


### PR DESCRIPTION
As a part of IAEMOD-3524, ngx-uswds table should be able to highlight the row the user is hovering over. SDS already has this behavior, this PR extends the styling specified for SDS to apply to the class applied to the USWDS table.