### PR TITLE
Fix NGX-USWDS table appearance when sam-styles applied

### DIFF
--- a/src/stylesheets/components/_table.scss
+++ b/src/stylesheets/components/_table.scss
@@ -288,4 +288,15 @@ $sds-table-border: "1px";
       }
     }
   }
+  &--stacked-header {
+    @include at-media-max("mobile-lg") {
+      tr{
+        td{
+          &:first-child{
+            padding-left: 0.75rem;
+          }
+        }
+      }
+    }
+  }
 }

--- a/src/stylesheets/components/_table.scss
+++ b/src/stylesheets/components/_table.scss
@@ -161,96 +161,103 @@ $sds-table-border: "1px";
       }
     }
   }
-  tr{
-    height: 3rem;
-  }
-  &--compact{
-    tr{
-      height: 100%;
+  @include at-media("tablet") {
+    tr {
+      height: 3rem;
+    }
+
+    &--compact {
+      tr {
+        height: 100%;
+      }
     }
   }
 
   &:not(.usa-table--borderless):not(.sds-tree-table) {
-    thead{
-      th,td {
-        /**
-        Overrides remaining borders to ensure correct color and width.
-        Must include :not(.mat-header-cell) in order to prevent a 2 px border from forming when sds-table extends usa-table
-        */
-        &:first-child:not(.mat-header-cell){
-          @include u-border-left('base-light', $sds-table-border); 
+    @include at-media("tablet") {
+      thead{
+        th,td {
+          /**
+          Overrides remaining borders to ensure correct color and width.
+          Must include :not(.mat-header-cell) in order to prevent a 2 px border from forming when sds-table extends usa-table
+          */
+          &:first-child:not(.mat-header-cell){
+            @include u-border-left('base-light', $sds-table-border); 
+          }
+          &:last-child:not(.mat-header-cell){
+            @include u-border-right('base-light', $sds-table-border); 
+          }
+          &:not(.mat-header-cell){
+            @include u-border-top('base-light', $sds-table-border);
+          }
         }
-        &:last-child:not(.mat-header-cell){
-          @include u-border-right('base-light', $sds-table-border); 
-        }
-        &:not(.mat-header-cell){
-          @include u-border-top('base-light', $sds-table-border);
+      }
+      tbody{
+        tr{
+          &:last-child{
+            td:not(.mat-cell) {
+              @include u-border-bottom('base-light', $sds-table-border);
+            }
+          }
+          th,td{
+            &:first-child:not(.mat-cell){
+              @include u-border-left('base-light', $sds-table-border);
+            }
+            &:last-child:not(.mat-cell){
+              @include u-border-right('base-light', $sds-table-border);
+            }
+          }
         }
       }
     }
-    tbody{
-      tr{
-        &:last-child{
-          td:not(.mat-cell) {
-            @include u-border-bottom('base-light', $sds-table-border);
-          }
+  }
+  @include at-media("tablet") {
+    thead {
+      th, td {
+        /**
+          Removes internal borders so that only borders on the outside edges of header remain
+        */
+        &:not(:first-child){
+          border-left: 0px;
         }
-        th,td{
-          &:first-child:not(.mat-cell){
-            @include u-border-left('base-light', $sds-table-border);
-          }
-          &:last-child:not(.mat-cell){
-            @include u-border-right('base-light', $sds-table-border);
-          }
+        &:not(:last-child){
+          border-right: 0px;
+        }
+        &:not(.mat-header-cell){
+          @include u-border-bottom('base-light', $sds-table-border);
+        }
+        padding-bottom: 0.5rem;
+        padding-top: 0.5rem;
+        padding-left: 1.5rem;
+        padding-right: 1rem;
+        background-color: color($theme-table-header-background-color);
+        
+      }
+    }
+    tbody {
+      tr{
+        th, td {
+          padding-bottom: 0.5rem;
+          padding-top: 0.5rem;
+          padding-left: 1.5rem;
+          padding-right: 1rem;
+  
+          /**
+          Removing internal horizontal borders from rows that divide the body into rows
+          */
+          border-bottom: 0px;
+          border-top: 0px;
+  
+          /**
+          Removing internal vertical borders from cells that divide the rows into columns
+          */
+          border-left: 0px;
+          border-right: 0px;
         }
       }
     }
   }
   
-  thead {
-    th, td {
-      /**
-        Removes internal borders so that only borders on the outside edges of header remain
-      */
-      &:not(:first-child){
-        border-left: 0px;
-      }
-      &:not(:last-child){
-        border-right: 0px;
-      }
-      &:not(.mat-header-cell){
-        @include u-border-bottom('base-light', $sds-table-border);
-      }
-      padding-bottom: 0.5rem;
-      padding-top: 0.5rem;
-      padding-left: 1.5rem;
-      padding-right: 1rem;
-      background-color: color($theme-table-header-background-color);
-      
-    }
-  }
-  tbody {
-    tr{
-      th, td {
-        padding-bottom: 0.5rem;
-        padding-top: 0.5rem;
-        padding-left: 1.5rem;
-        padding-right: 1rem;
-
-        /**
-        Removing internal horizontal borders from rows that divide the body into rows
-        */
-        border-bottom: 0px;
-        border-top: 0px;
-
-        /**
-        Removing internal vertical borders from cells that divide the rows into columns
-        */
-        border-left: 0px;
-        border-right: 0px;
-      }
-    }
-  }
   &--striped {
     tbody {
       tr:nth-child(even) {
@@ -271,6 +278,14 @@ $sds-table-border: "1px";
   thead {
     th[aria-sort] {
       background-color: color($theme-table-header-background-color);
+    }
+  }
+  &--stacked,
+  &--stacked-header {
+    @include at-media-max("mobile-lg") {
+      td:not(:first-child) {
+        border-top-width: 0px;
+      }
     }
   }
 }


### PR DESCRIPTION
Extra border:
before: 
<img width="459" alt="Screen Shot 2022-08-22 at 10 11 04 AM" src="https://user-images.githubusercontent.com/72805180/185942329-d6584942-a025-4d51-a690-972c9700e8c4.png">

after:
<img width="459" alt="Screen Shot 2022-08-22 at 3 39 55 PM" src="https://user-images.githubusercontent.com/72805180/186004878-b4c5d56d-7ecc-45d5-8363-b8caa0bd7373.png">

Compact Mode:
before:
<img width="459" alt="Screen Shot 2022-08-22 at 10 11 17 AM" src="https://user-images.githubusercontent.com/72805180/185942330-394fcb63-d4f4-42f3-8a01-ffa5b77b9557.png">
after:
<img width="459" alt="Screen Shot 2022-08-22 at 10 11 29 AM" src="https://user-images.githubusercontent.com/72805180/185942333-a664b3d5-0aee-4940-8918-c6e1480b7e40.png">
