### PR TITLE
Tooltip position is added to fixed

### DIFF
--- a/src/stylesheets/components/_popup.scss
+++ b/src/stylesheets/components/_popup.scss
@@ -267,6 +267,7 @@
     @include u-padding-y("05");
     @include u-text("normal");
     @include u-margin("1px");
+    position: fixed;
     min-width: 300px;
     max-width: 500px;
     text-indent: 0 !important;


### PR DESCRIPTION
This PR is to show the tooltip if the container width is fixed and overflow is hidden still want to show the tooltip.

Here is the issue Id: https://github.com/GSA/sam-design-system/issues/1099