### PR TITLE
Accordion header variant color for accent cool

### DIFF
--- a/src/stylesheets/components/_accordion.scss
+++ b/src/stylesheets/components/_accordion.scss
@@ -2,6 +2,12 @@
 
   @include u-padding-x(1);
 
+  &.usa-accordion--accent_cool {
+    .usa-accordion__button:not(.usa-banner__button) {
+      @include u-bg("accent-cool-lighter");
+    }
+  }
+
   .usa-accordion__button:not(.usa-banner__button) {
     @include u-bg("white");
     @include u-padding-right("205");


### PR DESCRIPTION
This pr is to add the accent cool color variant for the Accordion header

https://cm-jira.usa.gov/browse/IAEMOD-9762
<img width="1427" alt="Screen Shot 2023-02-09 at 3 19 47 PM" src="https://user-images.githubusercontent.com/44271677/217928013-34a7f1f8-0346-4070-8b0f-a87c6a733491.png">
