### PR TITLE
Accordion alternate color change with no border

### DIFF
--- a/src/stylesheets/components/_accordion.scss
+++ b/src/stylesheets/components/_accordion.scss
@@ -2,9 +2,16 @@
 
   @include u-padding-x(1);
 
+  &.border-0 {
+    .usa-accordion__button:not(.usa-banner__button) {
+      border: none !important;
+    }
+  }
+
   &.usa-accordion--accent_cool {
     .usa-accordion__button:not(.usa-banner__button) {
       @include u-bg("accent-cool-lighter");
+
     }
   }
 
@@ -56,7 +63,6 @@
     &[aria-expanded="true"] {
       background-image: none;
       @include u-text("secondary-dark");
-      background-color: white;
     }
 
     &[aria-expanded="false"] {
@@ -114,7 +120,7 @@
     @include u-bg("white");
     box-shadow: rgba(0, 0, 0, 0.25) 0px 1px 3px 0px inset;
     margin: 0px;
-    padding: 1em;
+    padding: 0.5em 1em;
     @include u-font("sans", "xs");
     font-size: 0.87rem;
 


### PR DESCRIPTION
The purpose of the PR is to allow to have alternate header color without the border and when expanded it should have the same background color
<img width="883" alt="Screen Shot 2023-02-23 at 4 10 23 PM" src="https://user-images.githubusercontent.com/44271677/221031110-d15c9108-b79b-4432-99f2-d4be195b2dee.png">
<img width="807" alt="Screen Shot 2023-02-23 at 4 10 40 PM" src="https://user-images.githubusercontent.com/44271677/221031117-ee37f80c-8230-4f9e-bf4d-7d6cc996ed63.png">
