### PR TITLE
removed border from unstyled disabled button

### DIFF
--- a/sam-styles/packages/components/button/styles/button.scss
+++ b/sam-styles/packages/components/button/styles/button.scss
@@ -529,6 +529,9 @@ $button-shadow: 0 0.25rem 0.5rem 0 rgba(0, 0, 0, 0.2);
       @include u-text("base");
       border: none !important;
       text-decoration: none;
+      &:hover {
+        font-weight: unset !important;
+      }
     }
   }
 }

--- a/sam-styles/packages/components/button/styles/button.scss
+++ b/sam-styles/packages/components/button/styles/button.scss
@@ -526,7 +526,9 @@ $button-shadow: 0 0.25rem 0.5rem 0 rgba(0, 0, 0, 0.2);
     &.usa-button--unstyled {
       box-shadow: none;
       @include u-bg("transparent");
-      @include u-text("disabled");
+      @include u-text("base");
+      border: none !important;
+      text-decoration: none;
     }
   }
 }


### PR DESCRIPTION
this PR addresses the following issue:
https://github.com/GSA/sam-design-system/issues/1305

it was caused because there was a border around the unstyled disabled button (which should not have been there).
the commit removes the border and removes an underline. it also fixes the text color. 

before:
![Screen Shot 2023-10-30 at 3 22 16 PM](https://github.com/GSA/sam-styles/assets/118462746/afd2308d-78ee-4342-976d-b196fc54a776)

after:
![Screen Shot 2023-10-30 at 3 23 40 PM](https://github.com/GSA/sam-styles/assets/118462746/110dfb96-5354-40cb-8d0b-52882ba5ece6)
