### PR TITLE
Fix CKEditor Styles

### DIFF
--- a/sam-styles/packages/sds-styles/rich-text-editor.scss
+++ b/sam-styles/packages/sds-styles/rich-text-editor.scss
@@ -1,17 +1,13 @@
 @for $i from 4 through 31 {
 
     .min-height-#{$i} {
-      ::ng-deep {
-        .ck-editor__editable_inline {
-          min-height: $i * 1rem;
-        }
+      .ck-editor__editable_inline {
+        min-height: $i * 1rem;
       }
     }
     .max-height-#{$i} {
-      ::ng-deep {
-        .ck-editor__editable_inline {
+      .ck-editor__editable_inline {
           max-height: $i * 1rem;
-        }
       }
     }
   }


### PR DESCRIPTION
Remove ::ng-deep to make CKEditor styles apply correctly.