### PR TITLE
Add workflows to deploy PR branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Node Packages
         run: npm i
       - name: Build Storybook Assets
-        run: npm run build-storybook
+        run: npm run build:storybook
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
       - name: Add .nojekyll file to allow for node_modules to be included in bundle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
       - name: Add .nojekyll file to allow for node_modules to be included in bundle
-        run: touch storybook-static/.nojekyll
+        run: touch _site/.nojekyll
       - name: Archive Storybook Assets
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build Storybook
+on:
+  workflow_call:
+    inputs:
+      pr-number:
+        required: false
+        type: string
+jobs:
+  Build-Storybook-Assets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18.x'
+      - name: Install Node Packages
+        run: npm i
+      - name: Build Storybook Assets
+        run: npm run build-storybook
+        env:
+          NODE_OPTIONS: "--max_old_space_size=8192"
+      - name: Add .nojekyll file to allow for node_modules to be included in bundle
+        run: touch storybook-static/.nojekyll
+      - name: Archive Storybook Assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: storybook-assets
+          path: _site
+          retention-days: 1

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -1,18 +1,25 @@
-name: Deploy to Github Pages
+name: Deploy PRs
 on:
-  push:
-    branches:
-      - master
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
 jobs:
   Build-Storybook:
+    if: github.event.action != 'closed'
     uses: ./.github/workflows/build.yml
+    with:
+        pr-number: ${{ github.event.number }}
   Deploy-Storybook:
     runs-on: ubuntu-latest
-    if: ${{ success() }}
+    if: ${{ !failure() }}
     needs: Build-Storybook
     steps:
+        # Only needed because rossjrw/pr-preview-action needs to run in a git repo
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Download Storybook Assets
         # If closing PR, build will not occur so nothing to download
         if: github.event.action != 'closed'
@@ -20,10 +27,7 @@ jobs:
         with:
           name: storybook-assets
           path: ./_site
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.2.3
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
         with:
-          branch: gh-pages
-          folder: _site
-          clean-exclude: pr-preview/
-          force: false
+          source-dir: ./_site/


### PR DESCRIPTION
Add workflow to build and deploy PRs for viewing on Github Pages.
Updated existing workflow to not trample PR branches.
Configured both workflows to use the same build workflow so that changed to the build do not require changes to multiple workflows
