### PR TITLE
Update sidenav styles allow for disabled sidenav items

### DIFF
--- a/sam-styles/packages/components/side-nav/styles/side-nav.scss
+++ b/sam-styles/packages/components/side-nav/styles/side-nav.scss
@@ -72,6 +72,13 @@
           color: color('secondary-dark');
           font-weight: font-weight('bold');
         }
+        &.disabled{
+          color: #c9c9c9 !important;
+          cursor: auto;
+          &:focus{
+            outline: none;
+          }
+        }
   
       }
     }


### PR DESCRIPTION
Add styles for a disabled class to apply to sidenav items.

When class is applied:
<img width="355" alt="image" src="https://github.com/user-attachments/assets/cb365574-e375-471a-9ec2-655ac0ca7ac7" />
