### PR TITLE
added top border for first child of side-nav item

### DIFF
--- a/sam-styles/packages/components/side-nav/styles/side-nav.scss
+++ b/sam-styles/packages/components/side-nav/styles/side-nav.scss
@@ -63,11 +63,18 @@
   
   
     .usa-sidenav__item{
-       @include u-border-top(0);
         @include u-border-x('1px');
         @include u-border-bottom('1px');
         @include u-border('base-light');
-  
+
+        &:first-child {
+            @include u-border-top('1px');
+        }
+        
+        &:not(:first-child) {
+            @include u-border-top(0);
+        }
+
         &.usa-current > a {
           color: color('secondary-dark');
           font-weight: font-weight('bold');


### PR DESCRIPTION
resolves https://github.com/GSA/sam-styles/issues/726

added top border for the first element of side nav item.
![Screen Shot 2025-01-30 at 8 40 59 AM](https://github.com/user-attachments/assets/b2dac2f3-dafa-41b4-a2a0-b10d35feabd3)
