### PR TITLE
build: enable Dependabot for npm and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,16 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 5
+      semver-major-days: 60
     groups:
       npm-dependencies:
         patterns:


### PR DESCRIPTION
## What changed

Adds `.github/dependabot.yml` to enable Dependabot for the **npm** and **github-actions** ecosystems.

**File added:** `.github/dependabot.yml`
- `package-ecosystem: npm` targeting the repo root (`/`), weekly
  - `open-pull-requests-limit: 10` and a grouped update so the initial backlog lands as a few reviewable PRs rather than churning at the default cap of 5
- `package-ecosystem: github-actions` targeting the repo root (`/`), weekly, grouped
  - Keeps CI action versions current on an ongoing basis. This complements #748 (a one-time manual audit + SHA-pin) by providing the *ongoing* mechanism that stops the actions drifting out of date again after that audit lands.

## Why

The repo currently has 70 known vulnerabilities (2 critical, 35 high) on the default branch. Enabling Dependabot is the first step toward automated dependency hygiene. Grouping + a raised PR limit keeps that backlog tractable at enablement.

Note: this PR only **enables the mechanism** — actually paying down the vulnerability backlog is tracked separately in #750 (blocked by this PR so the grouped update PRs can clear the easy wins first).

## Scope note

#734's acceptance criteria call for the npm ecosystem. This PR also enables the `github-actions` ecosystem because it is the same one-time enablement moment and directly supports the ongoing half of #748. Called out here for review transparency.

## How to test

1. Merge this PR.
2. Navigate to **Insights → Dependency graph → Dependabot** on the repo — both the `npm` and `github-actions` ecosystems should appear as configured.
3. Within a week (or after a manual "Check for updates"), Dependabot should open at least one update PR.

All local checks pass:
- `npm test` (stylelint) ✅
- `npm run compile:check` (SCSS compilation) ✅

## Closes

Closes #734
Refs #748, #750