### PR TITLE
ci: pin pr-preview-action to a commit sha

### DIFF
--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -31,6 +31,6 @@ jobs:
           name: storybook-assets
           path: ./_site
       - name: Deploy preview
-        uses: rossjrw/pr-preview-action@v1
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
         with:
           source-dir: ./_site/


### PR DESCRIPTION
## What changed

Pins the last unpinned GitHub Action in the repo — `rossjrw/pr-preview-action` — from the floating `@v1` tag to the `v1.8.1` commit SHA with a version comment:

```diff
- uses: rossjrw/pr-preview-action@v1
+ uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
```

### Context

The bulk of #748 (updating `actions/checkout`, `actions/setup-node`, `actions/upload-artifact`, `actions/download-artifact`, and `JamesIves/github-pages-deploy-action` to their latest majors and SHA-pinning them) was already delivered by the merged Dependabot PR #751. This PR closes out the one action Dependabot's `github-actions` group did not cover, completing the audit.

All action references across the four workflows are now on their latest major version and SHA-pinned with a version comment.

## How to test

- `grep -rnE 'uses:.*@v[0-9]+\s*$' .github/workflows/` returns no matches (no floating tags remain).
- `npm test` (stylelint) passes.
- `npm run compile:check` passes (`SCSS compilation: OK`).
- The `pr-workflow.yml` PR-preview job exercises the pinned action on this very PR.

## Screenshots

N/A — CI/workflow change only.

## Checklist

- [x] All actions on latest major version (verified SHAs against release tags)
- [x] All action references SHA-pinned with a version comment
- [ ] Workflows pass in CI (verified on this PR)

Closes #748
