### PR TITLE
test: add regression coverage for table and tree-table styles

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,6 +8,9 @@ public/
 # Dependencies
 node_modules/
 
+# Playwright test artefacts
+test-results/
+
 # Malformed HTML fragments that pre-date this PR — prettier cannot parse them
 sam-styles/packages/components/alerts/templates/overview.html
 sam-styles/packages/components/tags/status.html

--- a/sam-styles/packages/components/tables/tables.stories.js
+++ b/sam-styles/packages/components/tables/tables.stories.js
@@ -1,4 +1,5 @@
 import Table from "./templates/table.html";
+import TreeTable from "./templates/tree-table.html";
 
 export default {
   title: "Components",
@@ -6,4 +7,8 @@ export default {
 
 export const Tables = () => {
   return Table;
+};
+
+export const TreeTables = () => {
+  return TreeTable;
 };

--- a/sam-styles/packages/components/tables/templates/tree-table.html
+++ b/sam-styles/packages/components/tables/templates/tree-table.html
@@ -2,7 +2,7 @@
   <table class="usa-table sds-tree-table">
     <thead>
       <tr>
-        <th scope="col"></th>
+        <th scope="col"><span class="usa-sr-only">Expand/collapse</span></th>
         <th scope="col">Entity</th>
         <th scope="col">Status</th>
         <th scope="col">Expiration</th>

--- a/sam-styles/packages/components/tables/templates/tree-table.html
+++ b/sam-styles/packages/components/tables/templates/tree-table.html
@@ -13,8 +13,15 @@
       <tr aria-level="1" aria-expanded="true" class="text-left">
         <td>
           <button class="usa-button usa-button--unstyled" aria-label="collapse">
-            <svg aria-hidden="true" focusable="false" role="img" class="usa-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-              <g class="expanded"><path d="M19 13H5v-2h14v2z"/></g>
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              role="img"
+              class="usa-icon"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+            >
+              <g class="expanded"><path d="M19 13H5v-2h14v2z" /></g>
             </svg>
           </button>
         </td>

--- a/sam-styles/packages/components/tables/templates/tree-table.html
+++ b/sam-styles/packages/components/tables/templates/tree-table.html
@@ -1,0 +1,54 @@
+<div class="sds-tree-table--scrollable">
+  <table class="usa-table sds-tree-table">
+    <thead>
+      <tr>
+        <th scope="col"></th>
+        <th scope="col">Entity</th>
+        <th scope="col">Status</th>
+        <th scope="col">Expiration</th>
+      </tr>
+    </thead>
+    <tbody>
+      <!-- Level 1 expandable row -->
+      <tr aria-level="1" aria-expanded="true" class="text-left">
+        <td>
+          <button class="usa-button usa-button--unstyled" aria-label="collapse">
+            <svg aria-hidden="true" focusable="false" role="img" class="usa-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+              <g class="expanded"><path d="M19 13H5v-2h14v2z"/></g>
+            </svg>
+          </button>
+        </td>
+        <td>Parent Entity A</td>
+        <td>Active</td>
+        <td>12/31/2025</td>
+      </tr>
+      <!-- Level 2 child row -->
+      <tr aria-level="2" class="text-left">
+        <td>
+          <div class="vertical-border"></div>
+          <div class="horizontal-border"></div>
+        </td>
+        <td>Child Entity B</td>
+        <td>Active</td>
+        <td>06/30/2025</td>
+      </tr>
+      <!-- Level 2 selected row -->
+      <tr aria-level="2" class="sds-tree-table__row--selected text-left">
+        <td>
+          <div class="vertical-border"></div>
+          <div class="horizontal-border"></div>
+        </td>
+        <td>Child Entity C (selected)</td>
+        <td>Inactive</td>
+        <td>01/01/2024</td>
+      </tr>
+      <!-- Level 1 non-expandable row -->
+      <tr aria-level="1" class="text-left">
+        <td></td>
+        <td>Standalone Entity D</td>
+        <td>Active</td>
+        <td>03/15/2026</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/tests/storybook/table.spec.mjs
+++ b/tests/storybook/table.spec.mjs
@@ -48,9 +48,10 @@ test("hovered row cells get the hover background color", async ({ page }) => {
   await page.goto(STORY);
   await page.waitForLoadState("networkidle");
 
-  // Inject the hover class and read computed CSS in a single evaluate call,
-  // since the class addition doesn't trigger a DOM mutation event that
-  // Playwright's locator polling can observe on the already-present td elements.
+  // Inject the hover class and read computed CSS in a single evaluate call.
+  // Note: we use evaluate() here rather than Playwright locator polling because
+  // the class is added dynamically and we want to read the style in the same
+  // synchronous tick — avoiding a race between class addition and style resolution.
   const hoveredBg = await page.evaluate(() => {
     const row = document.querySelector(".sds-table tbody tr");
     if (!row) return null;

--- a/tests/storybook/table.spec.mjs
+++ b/tests/storybook/table.spec.mjs
@@ -1,0 +1,79 @@
+import { test, expect } from "@playwright/test";
+
+// Story: Components / Tables => iframe ID: components--tables
+const STORY = "/iframe.html?id=components--tables";
+
+test("standard table body cell has correct padding", async ({ page }) => {
+  await page.goto(STORY);
+
+  const cell = page.locator(".sds-table tbody .sds-table__row td").first();
+  await expect(cell).toBeVisible();
+
+  // At tablet breakpoint the usa-table override sets padding-left/right to 1.5rem/1rem = 24px/16px
+  // and padding-top/bottom to 0.5rem = 8px
+  await expect(cell).toHaveCSS("padding-top", "8px");
+  await expect(cell).toHaveCSS("padding-bottom", "8px");
+  await expect(cell).toHaveCSS("padding-left", "24px");
+  await expect(cell).toHaveCSS("padding-right", "16px");
+});
+
+test("table header cells have the correct background color", async ({ page }) => {
+  await page.goto(STORY);
+
+  const th = page.locator(".sds-table thead th").first();
+  await expect(th).toBeVisible();
+  // u-bg("base-lighter") / $theme-table-header-background-color resolved value
+  await expect(th).toHaveCSS("background-color", "rgb(245, 245, 240)");
+});
+
+test("even rows in a single-tbody table get tiger-stripe background", async ({ page }) => {
+  await page.goto(STORY);
+
+  // The first table has a single tbody (no subsection class), so tiger stripes apply
+  const evenCell = page
+    .locator(".sds-table tbody:only-of-type .sds-table__row:nth-of-type(even) td")
+    .first();
+  await expect(evenCell).toBeVisible();
+  // u-bg("base-lightest")
+  await expect(evenCell).toHaveCSS("background-color", "rgb(249, 249, 247)");
+});
+
+test("hovered row cells get the hover background color", async ({ page }) => {
+  await page.goto(STORY);
+  await page.waitForLoadState("networkidle");
+
+  // Inject the hover class and read computed CSS in a single evaluate call,
+  // since the class addition doesn't trigger a DOM mutation event that
+  // Playwright's locator polling can observe on the already-present td elements.
+  const hoveredBg = await page.evaluate(() => {
+    const row = document.querySelector(".sds-table tbody tr");
+    if (!row) return null;
+    row.classList.add("sds-table__row--hovered");
+    const td = document.querySelector(".sds-table tr.sds-table__row--hovered td");
+    return td ? getComputedStyle(td).backgroundColor : null;
+  });
+
+  // u-bg("base-light") !important
+  expect(hoveredBg).toBe("rgb(201, 201, 201)");
+});
+
+test("subsection header row has accent-cool-lighter highlight background", async ({ page }) => {
+  await page.goto(STORY);
+
+  const subsectionHeader = page
+    .locator("tbody.sds-table__subsection tr:first-child th")
+    .first();
+  await expect(subsectionHeader).toBeVisible();
+  // %sds-table--highlight => u-bg("accent-cool-lighter")
+  await expect(subsectionHeader).toHaveCSS("background-color", "rgb(239, 246, 251)");
+});
+
+test("table container has a visible border", async ({ page }) => {
+  await page.goto(STORY);
+
+  const container = page.locator(".sds-table__container").first();
+  await expect(container).toBeVisible();
+  // u-border("base-light") — confirms the container border is applied
+  await expect(container).toHaveCSS("border-color", "rgb(201, 201, 201)");
+  await expect(container).toHaveCSS("border-style", "solid");
+});

--- a/tests/storybook/table.spec.mjs
+++ b/tests/storybook/table.spec.mjs
@@ -17,7 +17,9 @@ test("standard table body cell has correct padding", async ({ page }) => {
   await expect(cell).toHaveCSS("padding-right", "16px");
 });
 
-test("table header cells have the correct background color", async ({ page }) => {
+test("table header cells have the correct background color", async ({
+  page,
+}) => {
   await page.goto(STORY);
 
   const th = page.locator(".sds-table thead th").first();
@@ -26,12 +28,16 @@ test("table header cells have the correct background color", async ({ page }) =>
   await expect(th).toHaveCSS("background-color", "rgb(245, 245, 240)");
 });
 
-test("even rows in a single-tbody table get tiger-stripe background", async ({ page }) => {
+test("even rows in a single-tbody table get tiger-stripe background", async ({
+  page,
+}) => {
   await page.goto(STORY);
 
   // The first table has a single tbody (no subsection class), so tiger stripes apply
   const evenCell = page
-    .locator(".sds-table tbody:only-of-type .sds-table__row:nth-of-type(even) td")
+    .locator(
+      ".sds-table tbody:only-of-type .sds-table__row:nth-of-type(even) td"
+    )
     .first();
   await expect(evenCell).toBeVisible();
   // u-bg("base-lightest")
@@ -49,7 +55,9 @@ test("hovered row cells get the hover background color", async ({ page }) => {
     const row = document.querySelector(".sds-table tbody tr");
     if (!row) return null;
     row.classList.add("sds-table__row--hovered");
-    const td = document.querySelector(".sds-table tr.sds-table__row--hovered td");
+    const td = document.querySelector(
+      ".sds-table tr.sds-table__row--hovered td"
+    );
     return td ? getComputedStyle(td).backgroundColor : null;
   });
 
@@ -57,7 +65,9 @@ test("hovered row cells get the hover background color", async ({ page }) => {
   expect(hoveredBg).toBe("rgb(201, 201, 201)");
 });
 
-test("subsection header row has accent-cool-lighter highlight background", async ({ page }) => {
+test("subsection header row has accent-cool-lighter highlight background", async ({
+  page,
+}) => {
   await page.goto(STORY);
 
   const subsectionHeader = page
@@ -65,7 +75,10 @@ test("subsection header row has accent-cool-lighter highlight background", async
     .first();
   await expect(subsectionHeader).toBeVisible();
   // %sds-table--highlight => u-bg("accent-cool-lighter")
-  await expect(subsectionHeader).toHaveCSS("background-color", "rgb(239, 246, 251)");
+  await expect(subsectionHeader).toHaveCSS(
+    "background-color",
+    "rgb(239, 246, 251)"
+  );
 });
 
 test("table container has a visible border", async ({ page }) => {

--- a/tests/storybook/tree-table.spec.mjs
+++ b/tests/storybook/tree-table.spec.mjs
@@ -1,0 +1,78 @@
+import { test, expect } from "@playwright/test";
+
+// Story: Components / TreeTables => iframe ID: components--tree-tables
+const STORY = "/iframe.html?id=components--tree-tables";
+
+test("tree-table header cells have accent-cool-lighter background", async ({
+  page,
+}) => {
+  await page.goto(STORY);
+
+  const th = page.locator(".sds-tree-table thead th").first();
+  await expect(th).toBeVisible();
+  // u-bg("accent-cool-lighter") from treetable.scss thead th rule
+  await expect(th).toHaveCSS("background-color", "rgb(239, 246, 251)");
+});
+
+test("expanded row data cells get base-lightest background", async ({
+  page,
+}) => {
+  await page.goto(STORY);
+
+  // tr[aria-expanded] td styling (not the first/icon cell)
+  const expandedCell = page
+    .locator("tr[aria-expanded] td:not(:first-child)")
+    .first();
+  await expect(expandedCell).toBeVisible();
+  // background-color: color("base-lightest")
+  await expect(expandedCell).toHaveCSS(
+    "background-color",
+    "rgb(249, 249, 247)"
+  );
+});
+
+test("level-1 rows have no extra indentation", async ({ page }) => {
+  await page.goto(STORY);
+
+  // tr[aria-level="1"] td:nth-child(2) left = (1 * 1.5) - 1.5 = 0rem
+  const cell = page.locator("tr[aria-level='1'] td:nth-child(2)").first();
+  await expect(cell).toBeVisible();
+  await expect(cell).toHaveCSS("left", "0px");
+});
+
+test("level-2 rows are indented by 1.5rem relative to level-1", async ({
+  page,
+}) => {
+  await page.goto(STORY);
+
+  // tr[aria-level="2"] td:nth-child(2) left = (2 * 1.5) - 1.5 = 1.5rem = 24px
+  const cell = page.locator("tr[aria-level='2'] td:nth-child(2)").first();
+  await expect(cell).toBeVisible();
+  await expect(cell).toHaveCSS("left", "24px");
+});
+
+test("selected tree-table row has secondary-color left border", async ({
+  page,
+}) => {
+  await page.goto(STORY);
+
+  const cell = page
+    .locator(".sds-tree-table__row--selected td:nth-child(2)")
+    .first();
+  await expect(cell).toBeVisible();
+  // u-border-left("secondary") — secondary color = rgb(38, 114, 222)
+  await expect(cell).toHaveCSS("border-left-color", "rgb(38, 114, 222)");
+});
+
+test("selected tree-table row has secondary-color top and bottom borders", async ({
+  page,
+}) => {
+  await page.goto(STORY);
+
+  const cell = page
+    .locator(".sds-tree-table__row--selected td:nth-child(2)")
+    .first();
+  await expect(cell).toBeVisible();
+  await expect(cell).toHaveCSS("border-top-color", "rgb(38, 114, 222)");
+  await expect(cell).toHaveCSS("border-bottom-color", "rgb(38, 114, 222)");
+});


### PR DESCRIPTION
## What changed

Adds Playwright style-regression tests for the `sds-table` and `sds-tree-table` components, filling the coverage gap identified in #763 (child of #759).

### Files changed

**`tests/storybook/table.spec.mjs`** *(new)*
Six tests against the existing `Components / Tables` story (`components--tables`):
- Standard body cell padding (8px top/bottom, 24px/16px left/right — tablet breakpoint override)
- Header cell `base-lighter` background
- Tiger-stripe: even rows in a single-tbody table get `base-lightest` background
- Hover row: injecting `.sds-table__row--hovered` causes cells to pick up `base-light` background
- Subsection header row gets `accent-cool-lighter` highlight
- Table container has the correct `base-light` border color and solid border style

**`tests/storybook/tree-table.spec.mjs`** *(new)*
Six tests against the new `Components / TreeTables` story (`components--tree-tables`):
- `thead th` cells have `accent-cool-lighter` background
- `tr[aria-expanded]` data cells get `base-lightest` background
- Level-1 rows have zero left offset (`left: 0px`)
- Level-2 rows are offset by `1.5rem` (`left: 24px`)
- Selected row (`.sds-tree-table__row--selected`) has secondary-color left border
- Selected row has secondary-color top and bottom borders

**`sam-styles/packages/components/tables/templates/tree-table.html`** *(new)*
Minimal but representative tree-table HTML fixture: two levels of nesting, an `aria-expanded="true"` parent row, and a `.sds-tree-table__row--selected` row — enough to exercise every tree-table AC item.

**`sam-styles/packages/components/tables/tables.stories.js`** *(modified)*
Exports a new `TreeTables` story backed by the fixture above, so Storybook serves it at `components--tree-tables`.

## Why

The `sds-table` and `sds-tree-table` SCSS files contain a dense set of stateful styles (tiger stripes, hover, subsection highlights, indentation by aria-level, selected-row borders). These were untested by Playwright and could silently regress after selector or nesting clean-up.

## How to test

```bash
# 1. Build Storybook
NODE_OPTIONS="--max_old_space_size=8192" npm run build:storybook

# 2. Run all Storybook regression tests (serves _site on port 6007)
npm run test:storybook
```

Expected: 13 tests pass (1 button + 6 table + 6 tree-table).

To verify the sentinel property (tests fail when styles break), remove a rule from `tables.scss` or `treetable.scss` and re-run — the corresponding test should turn red.

## Checklist

- [x] `npm run lint` passes (stylelint)
- [x] `npm run compile:check` passes (SCSS compilation OK)
- [x] `npm run test:storybook` — 13/13 Playwright tests pass
- [x] No new SCSS or JS production code — test/fixture/story additions only
- [x] Tree-table HTML fixture covers all AC items (indentation levels, expanded row, selected row)

Closes #763
