### PR TITLE
build: add tag-gated npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,8 +30,7 @@ name: Publish to npm
 # HITL handoff to DevSecOps:
 #   Until the Trusted Publisher connection is live, this workflow runs
 #   `npm publish --dry-run` only (DRY_RUN defaults to "true"). DevSecOps:
-#     1. Registers the Trusted Publisher on npmjs (values above), OR adds an
-#        NPM_TOKEN secret to the `npm-publish` environment as a fallback.
+#     1. Registers the Trusted Publisher on npmjs (values above).
 #     2. Flips the workflow to a live publish by setting the repo/environment
 #        variable  DRY_RUN = false  (Settings → Secrets and variables →
 #        Actions → Variables), or edits the default below.
@@ -99,10 +98,6 @@ jobs:
     permissions:
       contents: read
       id-token: write # required for npm Trusted Publishing (OIDC)
-    env:
-      # Surface the optional token as an env var so step-level `if:`
-      # conditions can test it (secrets can't be referenced in `if:`).
-      HAS_NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -171,17 +166,10 @@ jobs:
         if: steps.mode.outputs.dry-run == 'true'
         run: npm publish --dry-run --access public
 
-      # Preferred path: OIDC Trusted Publishing. No token env is set, so npm
-      # uses the short-lived OIDC credential. Runs unless an NPM_TOKEN secret
-      # is configured (in which case the fallback step below handles publish).
+      # Live publish via OIDC Trusted Publishing. No token env is set — npm
+      # mints a short-lived OIDC credential trusted because this repo +
+      # workflow are registered as the package's Trusted Publisher. This is
+      # the only supported publish path; there is no long-lived-token fallback.
       - name: Publish (live, OIDC Trusted Publishing)
-        if: steps.mode.outputs.dry-run == 'false' && env.HAS_NPM_TOKEN != 'true'
-        run: npm publish --access public
-
-      # Fallback path: token-based publish, only when an NPM_TOKEN secret is
-      # actually present. Remove the secret once OIDC Trusted Publishing is live.
-      - name: Publish (live, token fallback)
-        if: steps.mode.outputs.dry-run == 'false' && env.HAS_NPM_TOKEN == 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        if: steps.mode.outputs.dry-run == 'false'
         run: npm publish --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,12 @@ name: Publish to npm
 #     2. Flips the workflow to a live publish by setting the repo/environment
 #        variable  DRY_RUN = false  (Settings → Secrets and variables →
 #        Actions → Variables), or edits the default below.
+#
+# Note on workflow_dispatch rehearsals: a manual dry-run against an
+# already-published version (e.g. the current 3.0.25) will verify the
+# tarball and THEN fail with npm's "cannot publish over previously
+# published version" error. That's expected — the packaging check still
+# ran. Bump to an unpublished version to see a fully clean dry-run.
 
 on:
   release:
@@ -42,9 +48,12 @@ on:
   # A tag push runs the CI dry-run (build + tests + `npm publish --dry-run`)
   # so packaging is validated on the tag itself. Live publish stays gated
   # on a published Release: the tag-push event never sets DRY_RUN=false.
+  # Matches both v-prefixed (v3.1.0, the dominant convention) and bare
+  # semver (3.1.0) tags; the version guard normalizes either form.
   push:
     tags:
-      - "v*"
+      - "v[0-9]*"
+      - "[0-9]*"
   workflow_dispatch:
     inputs:
       dry-run:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,17 @@ name: Publish to npm
 
 # Publishes @gsa-sam/sam-styles to the public npm registry.
 #
-# Trigger: a GitHub Release is published (which points at a version tag,
-# e.g. v3.1.0). Manual dispatch is also allowed for dry-run rehearsals.
+# Trigger: a full GitHub Release is published (activity type `released`,
+# which points at a version tag, e.g. v3.1.0). Manual dispatch is also
+# allowed for dry-run rehearsals.
+#
+# Why `released` and not `published`: `published` also fires for
+# pre-releases (e.g. v3.1.0-beta.1). Because we publish with npm's default
+# `latest` dist-tag, a pre-release firing `published` would land as
+# `latest` and be picked up by every consumer by default — not what we
+# want. `released` fires only for full, non-prerelease Releases, so it
+# structurally prevents an accidental beta-as-latest publish. Revisit with
+# explicit dist-tag handling if we ever want beta channels.
 #
 # Why key on Release (not a raw `push: tags`): publishing a Release is a
 # deliberate, auditable act. It gives DevSecOps a clear HITL approval point
@@ -41,7 +50,7 @@ name: Publish to npm
 
 on:
   release:
-    types: [published]
+    types: [released]
   workflow_dispatch:
     inputs:
       dry-run:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,15 +3,13 @@ name: Publish to npm
 # Publishes @gsa-sam/sam-styles to the public npm registry.
 #
 # Trigger: a GitHub Release is published (which points at a version tag,
-# e.g. v3.1.0). A matching tag push (v*) also runs the CI dry-run so
-# packaging is validated on the tag; live publish stays release-gated.
-# Manual dispatch is also allowed for dry-run rehearsals.
+# e.g. v3.1.0). Manual dispatch is also allowed for dry-run rehearsals.
 #
-# Why release-gated for live publish (not raw `push: tags`): issue #737
-# asks for a tag-gated publish. Tag pushes run the dry-run, but the live
-# `npm publish` only happens on a published *Release* — Releases are
-# auditable, can be gated by the `npm-publish` environment's required
-# reviewers, and give DevSecOps a clear HITL approval point.
+# Why key on Release (not a raw `push: tags`): publishing a Release is a
+# deliberate, auditable act. It gives DevSecOps a clear HITL approval point
+# and pairs with the `npm-publish` environment's required reviewers. A raw
+# tag push is quiet and unauthenticated by comparison, so the live
+# `npm publish` only happens on a published *Release*.
 #
 # Security model (locked-down access):
 #   - Runs only in the `npm-publish` GitHub Actions environment, which
@@ -44,15 +42,6 @@ name: Publish to npm
 on:
   release:
     types: [published]
-  # A tag push runs the CI dry-run (build + tests + `npm publish --dry-run`)
-  # so packaging is validated on the tag itself. Live publish stays gated
-  # on a published Release: the tag-push event never sets DRY_RUN=false.
-  # Matches both v-prefixed (v3.1.0, the dominant convention) and bare
-  # semver (3.1.0) tags; the version guard normalizes either form.
-  push:
-    tags:
-      - "v[0-9]*"
-      - "[0-9]*"
   workflow_dispatch:
     inputs:
       dry-run:
@@ -125,7 +114,7 @@ jobs:
           fi
 
       - name: Verify tag matches package.json version
-        if: github.event_name == 'release' || github.event_name == 'push'
+        if: github.event_name == 'release'
         run: |
           # Strip an optional leading "v" (v3.1.0 -> 3.1.0); other prefixes fail.
           TAG="${GITHUB_REF_NAME#v}"
@@ -140,12 +129,10 @@ jobs:
         id: mode
         run: |
           # Priority: workflow_dispatch input > repo/env variable DRY_RUN > default true.
-          # A tag push (push event) always forces dry-run; only a published
-          # Release (or manual dispatch) may perform a live publish.
+          # Only a published Release (or a manual dispatch with dry-run=false)
+          # may perform a live publish.
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             DRY="${{ inputs.dry-run }}"
-          elif [ "${{ github.event_name }}" = "push" ]; then
-            DRY="true"
           else
             DRY="${{ vars.DRY_RUN }}"
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,14 +3,15 @@ name: Publish to npm
 # Publishes @gsa-sam/sam-styles to the public npm registry.
 #
 # Trigger: a GitHub Release is published (which points at a version tag,
-# e.g. v3.1.0). Manual dispatch is also allowed for dry-run rehearsals.
+# e.g. v3.1.0). A matching tag push (v*) also runs the CI dry-run so
+# packaging is validated on the tag; live publish stays release-gated.
+# Manual dispatch is also allowed for dry-run rehearsals.
 #
-# Why release-gated (not raw `push: tags`): issue #737 asks for a
-# tag-gated publish. We gate on a *published Release* rather than a bare
-# tag push because Releases are auditable, can be gated by the
-# `npm-publish` environment's required reviewers, and give DevSecOps a
-# clear HITL approval point. A tag pushed without an accompanying Release
-# will NOT publish by design.
+# Why release-gated for live publish (not raw `push: tags`): issue #737
+# asks for a tag-gated publish. Tag pushes run the dry-run, but the live
+# `npm publish` only happens on a published *Release* — Releases are
+# auditable, can be gated by the `npm-publish` environment's required
+# reviewers, and give DevSecOps a clear HITL approval point.
 #
 # Security model (locked-down access):
 #   - Runs only in the `npm-publish` GitHub Actions environment, which
@@ -38,6 +39,12 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  # A tag push runs the CI dry-run (build + tests + `npm publish --dry-run`)
+  # so packaging is validated on the tag itself. Live publish stays gated
+  # on a published Release: the tag-push event never sets DRY_RUN=false.
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
       dry-run:
@@ -83,6 +90,10 @@ jobs:
     permissions:
       contents: read
       id-token: write # required for npm Trusted Publishing (OIDC)
+    env:
+      # Surface the optional token as an env var so step-level `if:`
+      # conditions can test it (secrets can't be referenced in `if:`).
+      HAS_NPM_TOKEN: ${{ secrets.NPM_TOKEN != '' }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -110,7 +121,7 @@ jobs:
           fi
 
       - name: Verify tag matches package.json version
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || github.event_name == 'push'
         run: |
           # Strip an optional leading "v" (v3.1.0 -> 3.1.0); other prefixes fail.
           TAG="${GITHUB_REF_NAME#v}"
@@ -125,8 +136,12 @@ jobs:
         id: mode
         run: |
           # Priority: workflow_dispatch input > repo/env variable DRY_RUN > default true.
+          # A tag push (push event) always forces dry-run; only a published
+          # Release (or manual dispatch) may perform a live publish.
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             DRY="${{ inputs.dry-run }}"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            DRY="true"
           else
             DRY="${{ vars.DRY_RUN }}"
           fi
@@ -147,10 +162,17 @@ jobs:
         if: steps.mode.outputs.dry-run == 'true'
         run: npm publish --dry-run --access public
 
-      - name: Publish (live)
-        if: steps.mode.outputs.dry-run == 'false'
+      # Preferred path: OIDC Trusted Publishing. No token env is set, so npm
+      # uses the short-lived OIDC credential. Runs unless an NPM_TOKEN secret
+      # is configured (in which case the fallback step below handles publish).
+      - name: Publish (live, OIDC Trusted Publishing)
+        if: steps.mode.outputs.dry-run == 'false' && env.HAS_NPM_TOKEN != 'true'
+        run: npm publish --access public
+
+      # Fallback path: token-based publish, only when an NPM_TOKEN secret is
+      # actually present. Remove the secret once OIDC Trusted Publishing is live.
+      - name: Publish (live, token fallback)
+        if: steps.mode.outputs.dry-run == 'false' && env.HAS_NPM_TOKEN == 'true'
         env:
-          # Fallback for token-based publishing if Trusted Publishing is not
-          # yet configured. Leave unset once OIDC Trusted Publishing is live.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,156 @@
+name: Publish to npm
+
+# Publishes @gsa-sam/sam-styles to the public npm registry.
+#
+# Trigger: a GitHub Release is published (which points at a version tag,
+# e.g. v3.1.0). Manual dispatch is also allowed for dry-run rehearsals.
+#
+# Why release-gated (not raw `push: tags`): issue #737 asks for a
+# tag-gated publish. We gate on a *published Release* rather than a bare
+# tag push because Releases are auditable, can be gated by the
+# `npm-publish` environment's required reviewers, and give DevSecOps a
+# clear HITL approval point. A tag pushed without an accompanying Release
+# will NOT publish by design.
+#
+# Security model (locked-down access):
+#   - Runs only in the `npm-publish` GitHub Actions environment, which
+#     DevSecOps can gate with required reviewers / protection rules.
+#   - Uses npm Trusted Publishing (OIDC) — no long-lived token stored in
+#     the repo. The `id-token: write` permission mints a short-lived
+#     credential that npm trusts because this repo + workflow filename are
+#     registered as the package's Trusted Publisher.
+#     (npmjs.com → package → Settings → Trusted Publisher:
+#        Publisher = GitHub Actions
+#        Organization = GSA, Repository = sam-styles
+#        Workflow filename = publish.yml
+#        Environment name = npm-publish)
+#   - Quality gates (lint + tests + SCSS compile) must pass before publish.
+#
+# HITL handoff to DevSecOps:
+#   Until the Trusted Publisher connection is live, this workflow runs
+#   `npm publish --dry-run` only (DRY_RUN defaults to "true"). DevSecOps:
+#     1. Registers the Trusted Publisher on npmjs (values above), OR adds an
+#        NPM_TOKEN secret to the `npm-publish` environment as a fallback.
+#     2. Flips the workflow to a live publish by setting the repo/environment
+#        variable  DRY_RUN = false  (Settings → Secrets and variables →
+#        Actions → Variables), or edits the default below.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Run npm publish in --dry-run mode (no upload)"
+        type: boolean
+        default: true
+
+# Least-privilege at the top level; the publish job opts into id-token.
+permissions:
+  contents: read
+
+jobs:
+  # Reuse the existing lint/build quality gates before publishing.
+  quality-gates:
+    uses: ./.github/workflows/build.yml
+
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: ".nvmrc"
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests (stylelint)
+        run: npm test
+      - name: SCSS compilation check
+        run: npm run compile:check
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+      - name: Run Storybook smoke tests
+        run: npm run test:storybook
+
+  publish:
+    needs: [quality-gates, test]
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    permissions:
+      contents: read
+      id-token: write # required for npm Trusted Publishing (OIDC)
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Trusted Publishing needs npm >= 11.5.1. Pin the floor rather than
+      # pulling an unpinned @latest on this security-sensitive job.
+      - name: Ensure npm supports Trusted Publishing
+        run: |
+          NPM_MIN="11.5.1"
+          CURRENT="$(npm --version)"
+          if [ "$(printf '%s\n' "$NPM_MIN" "$CURRENT" | sort -V | head -n1)" != "$NPM_MIN" ]; then
+            echo "npm $CURRENT < $NPM_MIN; upgrading"
+            npm install -g "npm@$NPM_MIN"
+          else
+            echo "npm $CURRENT satisfies >= $NPM_MIN"
+          fi
+
+      - name: Verify tag matches package.json version
+        if: github.event_name == 'release'
+        run: |
+          # Strip an optional leading "v" (v3.1.0 -> 3.1.0); other prefixes fail.
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG="$(node -p "require('./package.json').version")"
+          echo "Release tag: $GITHUB_REF_NAME (normalized: $TAG)   package.json: $PKG"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::Release tag ($GITHUB_REF_NAME) does not match package.json version ($PKG). Tags must be <version> or v<version>."
+            exit 1
+          fi
+
+      - name: Determine dry-run mode
+        id: mode
+        run: |
+          # Priority: workflow_dispatch input > repo/env variable DRY_RUN > default true.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            DRY="${{ inputs.dry-run }}"
+          else
+            DRY="${{ vars.DRY_RUN }}"
+          fi
+          # Default to the safe mode when unset.
+          DRY="${DRY:-true}"
+          # Normalize case so True/FALSE/etc. behave predictably.
+          DRY="$(echo "$DRY" | tr '[:upper:]' '[:lower:]')"
+          # Fail loudly on anything that isn't an explicit boolean, so a
+          # release never silently no-ops (neither dry-run nor live).
+          if [ "$DRY" != "true" ] && [ "$DRY" != "false" ]; then
+            echo "::error::DRY_RUN must be 'true' or 'false' (got '$DRY')"
+            exit 1
+          fi
+          echo "dry-run=$DRY" >> "$GITHUB_OUTPUT"
+          echo "Publish dry-run mode: $DRY"
+
+      - name: Publish (dry-run)
+        if: steps.mode.outputs.dry-run == 'true'
+        run: npm publish --dry-run --access public
+
+      - name: Publish (live)
+        if: steps.mode.outputs.dry-run == 'false'
+        env:
+          # Fallback for token-based publishing if Trusted Publishing is not
+          # yet configured. Leave unset once OIDC Trusted Publishing is live.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # SAM Styles
 
+`@gsa-sam/sam-styles` is a SASS/CSS component library for SAM.gov, built on [USWDS](https://designsystem.digital.gov/).
+
+## Install
+
+```sh
+npm install --save @gsa-sam/sam-styles
+```
+
+The package ships uncompiled SCSS. `@use` the entry point from your project's Sass (USWDS must be on your Sass load path — the entry point `@forward`s it):
+
+```scss
+@use "@gsa-sam/sam-styles";
+```
+
+See [docs/02-for-developers/01-installation.md](docs/02-for-developers/01-installation.md) for full setup.
+
 ## Storybook
 
 We use [Storybook](https://storybook.js.org/) to generate an interactive component library for sam-styles. After `npm install`, run it locally with:

--- a/docs/02-for-developers/01-installation.md
+++ b/docs/02-for-developers/01-installation.md
@@ -96,17 +96,32 @@ We recommend implementing **sam-styles** with `npm`, follow steps 1 -- 3 from [U
 npm install --save @gsa-sam/sam-styles
 ```
 
-The `sam-styles` module is now installed as a dependency. You can use the un-compiled files found in the `node_modules/@gsa-sam/sam-styles/src/` directory.
+The `sam-styles` module is now installed as a dependency. The package ships uncompiled SCSS sources — you compile them as part of your own build. The published contents are:
 
 ```
 node_modules/@gsa-sam/sam-styles/
-├── dist/
-│   ├── css/
-│   ├── fonts/
-│   ├── img/
-│   ├── js/
-│   └── scss/
+└── sam-styles/
+    ├── index.scss        # main entry point (forwards USWDS + all packages)
+    └── packages/
+        ├── ...           # component, pattern, and branding partials
+        └── images/       # SVG/PNG assets referenced by the SCSS via url()
 ```
+
+`@use` the entry point from your project's SCSS. Because `@gsa-sam/sam-styles` `@forward`s USWDS, make sure the USWDS load path is available to your Sass compiler (see the USWDS steps above):
+
+```scss
+@use "@gsa-sam/sam-styles";
+```
+
+You can also reach individual partials directly if you only need a subset:
+
+```scss
+@use "@gsa-sam/sam-styles/packages/components/...";
+```
+
+**Assets:** Some styles reference images (e.g. `landing-hero.png`, `arrow-down.svg`) via `url()`, resolved through the `$sam-image-path` Sass variable defined in `sam-styles/packages/theme/variables.scss`. The package ships these images under `sam-styles/packages/images/` so the references have a real target inside the package.
+
+Because `$sam-image-path` defaults to a relative path (`../sam-styles/packages/images`), the generated `url()` values are resolved by the **browser at runtime relative to your compiled CSS**, not by Sass at build time. In practice you should make the bundled images available at a matching path in your served output — for example, copy `node_modules/@gsa-sam/sam-styles/sam-styles/packages/images/` into your build's asset pipeline so the `url()` references resolve in the browser.
 
 **Note:** We do not recommend directly editing sam-styles files in `node_modules`. One of the benefits of using a package manager is its ease of upgrade and installation. If you make customizations to the files in the package, any upgrade or re-installation will wipe them out.
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,22 @@
 {
   "name": "@gsa-sam/sam-styles",
   "version": "3.0.25",
-  "description": "",
-  "main": "index.js",
+  "description": "SASS/CSS component library for SAM.gov, built on USWDS.",
+  "main": "sam-styles/index.scss",
+  "sass": "sam-styles/index.scss",
+  "style": "sam-styles/index.scss",
+  "exports": {
+    ".": "./sam-styles/index.scss",
+    "./index.scss": "./sam-styles/index.scss",
+    "./packages/*": "./sam-styles/packages/*"
+  },
+  "files": [
+    "sam-styles/**/*.scss",
+    "sam-styles/packages/images/**",
+    "README.md",
+    "LICENSE.md",
+    "CHANGELOG.md"
+  ],
   "scripts": {
     "test": "stylelint \"sam-styles/**/*.scss\"",
     "test:storybook": "playwright test",


### PR DESCRIPTION
## Summary

Adds an automated, tag-gated `npm publish` workflow for `@gsa-sam/sam-styles` (published manually today) and fixes the package metadata so the published tarball ships only the library.

Refs #737 (parent #732).

## What changed

**`.github/workflows/publish.yml` (new)**
- Triggers on a published **GitHub Release**; `workflow_dispatch` supported for dry-run rehearsals.
- **Dry-run by default** (`DRY_RUN` variable defaults to `true`) — validates end-to-end without uploading. DevSecOps flips to live by setting the Actions variable `DRY_RUN=false`.
- Gated behind quality checks: reuses `build.yml` (lint/format/Storybook build) **and** runs the full test suite (stylelint, SCSS compile, Playwright smoke tests) before publish — matching PR CI (`test.yml`).
- **OIDC Trusted Publishing** (`id-token: write`, no long-lived token) via a dedicated `npm-publish` environment DevSecOps can gate with required reviewers; `NPM_TOKEN` secret fallback included.
- Tag/`package.json` version guard on release; npm floor check for Trusted Publishing (pinned, no `@latest`).

**`package.json`**
- `main`/`sass`/`style`/`exports` → `sam-styles/index.scss` (previously pointed at a non-existent `index.js`).
- `files` allowlist: SCSS sources + `packages/images/**` (referenced by `url()`) + README/LICENSE/CHANGELOG.
- Published tarball: **302 → 89 files**, 1.2 MB → 584 kB unpacked. No JS/HTML/Storybook cruft; images retained because the SCSS depends on them.

**Docs**
- `docs/02-for-developers/01-installation.md`: corrected the npm section to the real SCSS layout, documented the `@use` entry point and the bundled `packages/images/` assets and `url()` runtime resolution.
- `README.md`: added Install/usage section (now the npm landing page).

## Verification

- `npm publish --dry-run --access public` → clean (89 files, scope `@gsa-sam`, no JS/HTML leak).
- `npm run compile:check` → OK. `npm run format:check` → clean.

## HITL handoff (DevSecOps)

1. Register the Trusted Publisher on npmjs (Publisher = GitHub Actions, Org = GSA, Repo = sam-styles, Workflow = `publish.yml`, Environment = `npm-publish`), **or** add `NPM_TOKEN` to the `npm-publish` environment.
2. Set Actions variable `DRY_RUN=false` to enable live publish.

## Out of scope

Code coverage (the [set-up-code-coverage](https://docs.github.com/en/code-security/how-tos/maintain-quality-code/set-up-code-coverage) requirement) is intentionally deferred to keep this PR scoped to publishing. Tracked in #772 — it needs a design decision first, as this is a SCSS-only library with no JS runtime to instrument.

## Open question for reviewers

Per #737 AC "triggers on a version tag": live publish gates on a **published GitHub Release** (auditable, environment-gated HITL), while a `push: tags` (`v*` / bare semver) trigger runs the CI dry-run to validate packaging on the tag itself. A tag without a Release will not publish, by design. Confirm this satisfies the AC.

