### PR TITLE
build: add component/story coverage reporting for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         run: npm run coverage
 
       - name: Post coverage report as PR comment
-        if: always() && github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,8 +53,7 @@ jobs:
             }
             const body = fs.readFileSync(reportPath, 'utf8');
             const marker = '<!-- sam-styles-coverage-report -->';
-            const fullBody = `${marker}
-${body}`;
+            const fullBody = marker + '\n' + body;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -36,9 +37,61 @@ jobs:
       - name: Run Storybook smoke tests
         run: npm run test:storybook
 
+      - name: Run component/story coverage check
+        run: npm run coverage
+
+      - name: Post coverage report as PR comment
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+            const reportPath = 'coverage/component-coverage.md';
+            if (!fs.existsSync(reportPath)) {
+              console.log('Coverage report not found, skipping comment.');
+              return;
+            }
+            const body = fs.readFileSync(reportPath, 'utf8');
+            const marker = '<!-- sam-styles-coverage-report -->';
+            const fullBody = `${marker}
+${body}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find((c) => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: fullBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: fullBody,
+              });
+            }
+
       - name: Upload compilation report artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: scss-compilation-report
           path: coverage/compilation-report.txt
+          retention-days: 30
+
+      - name: Upload coverage report artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: component-coverage-report
+          path: |
+            coverage/component-coverage.json
+            coverage/component-coverage.md
           retention-days: 30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,19 @@
 - `npm run test:storybook` — Playwright smoke-style regression tests. Builds Storybook, serves the static `_site/` output via `http-server`, and runs Chromium checks against Storybook iframe URLs (asserting computed styles on rendered stories). Requires the Chromium browser (`npx playwright install chromium`) — Playwright config (`playwright.config.mjs`) and specs (`tests/storybook/*.spec.mjs`) are ESM.
 - `npm run compile:check` — compiles `sam-styles/index.scss` via `sass` (all load paths pre-set); writes `coverage/compilation-report.txt`. Exits 0 on success. USWDS deprecation WARNINGs are pre-existing noise, not failures.
 - `npm run lint` — alias; same as `npm test`.
+- `npm run coverage` — runs `scripts/coverage-report.mjs`; writes `coverage/component-coverage.json` and `coverage/component-coverage.md`. Exits 0 if coverage meets the threshold (currently **35%**), exits 1 otherwise.
+
+## Code coverage
+
+This is a SCSS-only library with no JS runtime. "Coverage" is measured as **component/story coverage**:
+
+> Every Storybook story file (`.stories.js`) in `sam-styles/packages/` should have at least one matching Playwright smoke-test spec in `tests/storybook/`.
+
+- **Metric**: `(stories with a Playwright spec) / (total stories) × 100`
+- **Current threshold**: 35% — CI fails if coverage drops below this.
+- **Target**: 80–90% (tracked in a separate issue — add specs for uncovered components).
+- **Reports**: `coverage/component-coverage.json` (machine-readable) and `coverage/component-coverage.md` (posted as a PR comment by CI).
+- **To raise the threshold**: update the `--threshold` value in the `coverage` script in `package.json` once enough new specs have been added.
 
 Build gotcha: the Storybook build needs extra heap. CI sets `NODE_OPTIONS="--max_old_space_size=8192"`; use the same locally if `build:storybook` OOMs.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,7 @@ This is a SCSS-only library with no JS runtime. "Coverage" is measured as **comp
 ### Adding coverage for a new component
 
 When you add a new `.stories.js` file, add a corresponding spec in `tests/storybook/<component-name>.spec.mjs` that:
+
 1. Navigates to the story via `page.goto('/iframe.html?id=<story-id>')`
 2. Asserts at least one computed CSS property on a rendered element
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,3 +98,27 @@ After your pull request is merged, you can safely delete your branch and pull th
   ```shell
   git pull origin master
   ```
+
+## Code coverage
+
+This is a SCSS-only library with no JS runtime. "Coverage" is measured as **component/story coverage**:
+
+> Every Storybook story file (`.stories.js`) in `sam-styles/packages/` should have at least one matching Playwright smoke-test spec in `tests/storybook/`.
+
+### How it works
+
+- `npm run coverage` runs `scripts/coverage-report.mjs` and writes:
+  - `coverage/component-coverage.json` — machine-readable results
+  - `coverage/component-coverage.md` — human-readable markdown table
+- CI runs this check on every PR and posts the report as a PR comment.
+- The check fails (exits 1) if coverage drops below the configured threshold (currently **35%**).
+
+### Adding coverage for a new component
+
+When you add a new `.stories.js` file, add a corresponding spec in `tests/storybook/<component-name>.spec.mjs` that:
+1. Navigates to the story via `page.goto('/iframe.html?id=<story-id>')`
+2. Asserts at least one computed CSS property on a rendered element
+
+### Raising the threshold
+
+Once enough specs have been added to push coverage above a new watermark, update the `--threshold=N` value in the `coverage` script in `package.json` and commit the change.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "stylelint \"sam-styles/**/*.scss\"",
     "test:storybook": "playwright test",
     "compile:check": "node scripts/compile-check.mjs",
-    "coverage": "node scripts/coverage-report.mjs",
+    "coverage": "node scripts/coverage-report.mjs --threshold=35",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "storybook": "storybook dev -p 6006",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "stylelint \"sam-styles/**/*.scss\"",
     "test:storybook": "playwright test",
     "compile:check": "node scripts/compile-check.mjs",
+    "coverage": "node scripts/coverage-report.mjs",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "storybook": "storybook dev -p 6006",

--- a/scripts/coverage-report.mjs
+++ b/scripts/coverage-report.mjs
@@ -21,13 +21,7 @@
  *   node scripts/coverage-report.mjs [--threshold=<n>]
  */
 
-import {
-  readdirSync,
-  readFileSync,
-  mkdirSync,
-  writeFileSync,
-  existsSync,
-} from "fs";
+import { readdirSync, readFileSync, mkdirSync, writeFileSync } from "fs";
 import { join, dirname, relative } from "path";
 import { fileURLToPath } from "url";
 
@@ -42,11 +36,17 @@ const OUT_DIR = join(ROOT, "coverage");
 
 // Parse --threshold=N from argv, fallback to env var, then default 35
 const thresholdArg = process.argv.find((a) => a.startsWith("--threshold="));
-const THRESHOLD = thresholdArg
-  ? parseInt(thresholdArg.split("=")[1], 10)
-  : process.env.COVERAGE_THRESHOLD
-    ? parseInt(process.env.COVERAGE_THRESHOLD, 10)
-    : 35;
+const thresholdValue = thresholdArg
+  ? thresholdArg.split("=")[1]
+  : process.env.COVERAGE_THRESHOLD || "35";
+const THRESHOLD = Number(thresholdValue);
+
+if (!Number.isInteger(THRESHOLD) || THRESHOLD < 0 || THRESHOLD > 100) {
+  process.stderr.write(
+    `Invalid coverage threshold "${thresholdValue}". Use an integer from 0 to 100.\n`
+  );
+  process.exit(1);
+}
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -100,12 +100,36 @@ function buildCoveredSet(specsDir) {
   return covered;
 }
 
+/** Convert Storybook title/export text to Storybook's generated id segment. */
+function toStorybookId(value, { splitCamelCase = false } = {}) {
+  const normalized = splitCamelCase
+    ? value.replace(/([a-z])([A-Z])/g, "$1-$2")
+    : value;
+
+  return normalized
+    .trim()
+    .replace(/[^a-zA-Z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .toLowerCase();
+}
+
+/** Extract the Storybook title and named stories from a CSF story file. */
+function storyMetadata(absPath) {
+  const content = readFileSync(absPath, "utf8");
+  const titleMatch = content.match(/title:\s*["']([^"']+)["']/);
+  const title = titleMatch ? titleMatch[1] : null;
+  const exports = [
+    ...content.matchAll(/export\s+const\s+([A-Za-z0-9_$]+)\s*=/g),
+  ].map(([, name]) => name);
+
+  return { title, exports };
+}
+
 /**
- * Derive a match key from a story file path.
- * e.g. "components/accordion/accordion.stories.js"
- *   → tries: "components-accordion", "accordion"
+ * Derive match keys from a story file path and Storybook metadata.
+ * e.g. title "Components", export "Tables" → "components--tables"
  */
-function storyMatchKeys(relPath) {
+function storyMatchKeys(relPath, absPath) {
   // relPath like "components/accordion/accordion.stories.js"
   const segments = relPath.replace(/\\/g, "/").split("/");
   // Remove filename
@@ -115,7 +139,20 @@ function storyMatchKeys(relPath) {
   // Group prefix = join all segments with "-"
   const prefix = segments.join("-");
 
-  return [prefix, componentName, relPath];
+  const keys = new Set([prefix, componentName, relPath]);
+  const { title, exports } = storyMetadata(absPath);
+
+  if (title) {
+    const titleId = toStorybookId(title);
+    keys.add(titleId);
+    for (const exportName of exports) {
+      keys.add(
+        `${titleId}--${toStorybookId(exportName, { splitCamelCase: true })}`
+      );
+    }
+  }
+
+  return [...keys];
 }
 
 // ── Main ──────────────────────────────────────────────────────────────────────
@@ -127,7 +164,7 @@ const coveredKeys = buildCoveredSet(SPECS_DIR);
 
 const rows = storyFiles.map((absPath) => {
   const relPath = relative(PACKAGES_DIR, absPath);
-  const keys = storyMatchKeys(relPath);
+  const keys = storyMatchKeys(relPath, absPath);
   const isCovered = keys.some((k) => coveredKeys.has(k));
   return { path: relPath, covered: isCovered };
 });

--- a/scripts/coverage-report.mjs
+++ b/scripts/coverage-report.mjs
@@ -21,9 +21,9 @@
  *   node scripts/coverage-report.mjs [--threshold=<n>]
  */
 
-import { readdirSync, readFileSync, mkdirSync, writeFileSync } from "fs";
-import { join, dirname, relative } from "path";
-import { fileURLToPath } from "url";
+import { readdirSync, readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { join, dirname, relative } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, "..");

--- a/scripts/coverage-report.mjs
+++ b/scripts/coverage-report.mjs
@@ -1,0 +1,210 @@
+/**
+ * scripts/coverage-report.mjs
+ *
+ * Component/Story Coverage Report
+ * ================================
+ * For a SCSS-only library with no JS runtime, "coverage" means:
+ *   - Every component that has a Storybook story (.stories.js) should also
+ *     have at least one Playwright smoke-test spec in tests/storybook/.
+ *
+ * Metric: covered stories / total stories  (× 100 = %)
+ *
+ * Outputs:
+ *   coverage/component-coverage.json   — machine-readable results
+ *   coverage/component-coverage.md     — human-readable markdown table
+ *
+ * Exits:
+ *   0  — coverage meets or exceeds COVERAGE_THRESHOLD (default 35%)
+ *   1  — coverage is below threshold (fails CI)
+ *
+ * Usage:
+ *   node scripts/coverage-report.mjs [--threshold=<n>]
+ */
+
+import { readdirSync, readFileSync, mkdirSync, writeFileSync, existsSync } from "fs";
+import { join, dirname, relative } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..");
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+const PACKAGES_DIR = join(ROOT, "sam-styles", "packages");
+const SPECS_DIR = join(ROOT, "tests", "storybook");
+const OUT_DIR = join(ROOT, "coverage");
+
+// Parse --threshold=N from argv, fallback to env var, then default 35
+const thresholdArg = process.argv.find((a) => a.startsWith("--threshold="));
+const THRESHOLD = thresholdArg
+  ? parseInt(thresholdArg.split("=")[1], 10)
+  : process.env.COVERAGE_THRESHOLD
+  ? parseInt(process.env.COVERAGE_THRESHOLD, 10)
+  : 35;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Recursively find all files matching a predicate under a directory. */
+function walkFiles(dir, predicate) {
+  const results = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...walkFiles(full, predicate));
+    } else if (predicate(entry.name)) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+/**
+ * Build a set of "covered" story keys from Playwright spec files.
+ * We scan each spec for page.goto() calls containing iframe.html?id=
+ * and extract the story id prefix (e.g. "components-accordion").
+ * We also record raw spec filenames (stem) as fallback keys.
+ */
+function buildCoveredSet(specsDir) {
+  const covered = new Set();
+  const specFiles = readdirSync(specsDir).filter((f) => f.endsWith(".spec.mjs"));
+
+  for (const file of specFiles) {
+    // Stem as a fallback key (e.g. "accordion" from "accordion.spec.mjs")
+    const stem = file.replace(/\.spec\.mjs$/, "");
+    covered.add(stem);
+
+    const content = readFileSync(join(specsDir, file), "utf8");
+
+    // Extract all storybook iframe IDs: ?id=components-accordion--multiselectable
+    const idMatches = content.matchAll(/[?&]id=([^"'&\s]+)/g);
+    for (const [, id] of idMatches) {
+      // e.g. "components-accordion--multiselectable" → add full id and prefix
+      covered.add(id);
+      // Add the story-group prefix before "--"
+      const prefix = id.split("--")[0]; // "components-accordion"
+      covered.add(prefix);
+      // Also add just the last segment of the prefix (component name)
+      const parts = prefix.split("-");
+      covered.add(parts[parts.length - 1]); // "accordion"
+    }
+  }
+
+  return covered;
+}
+
+/**
+ * Derive a match key from a story file path.
+ * e.g. "components/accordion/accordion.stories.js"
+ *   → tries: "components-accordion", "accordion"
+ */
+function storyMatchKeys(relPath) {
+  // relPath like "components/accordion/accordion.stories.js"
+  const segments = relPath.replace(/\\/g, "/").split("/");
+  // Remove filename
+  segments.pop();
+  // Component name = last dir segment
+  const componentName = segments[segments.length - 1];
+  // Group prefix = join all segments with "-"
+  const prefix = segments.join("-");
+
+  return [prefix, componentName, relPath];
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+const storyFiles = walkFiles(PACKAGES_DIR, (name) => name.endsWith(".stories.js"));
+const coveredKeys = buildCoveredSet(SPECS_DIR);
+
+const rows = storyFiles.map((absPath) => {
+  const relPath = relative(PACKAGES_DIR, absPath);
+  const keys = storyMatchKeys(relPath);
+  const isCovered = keys.some((k) => coveredKeys.has(k));
+  return { path: relPath, covered: isCovered };
+});
+
+const total = rows.length;
+const covered = rows.filter((r) => r.covered).length;
+const uncovered = total - covered;
+const pct = total === 0 ? 100 : Math.round((covered / total) * 100);
+const passed = pct >= THRESHOLD;
+
+// ── Write outputs ─────────────────────────────────────────────────────────────
+
+mkdirSync(OUT_DIR, { recursive: true });
+
+// JSON
+const json = {
+  threshold: THRESHOLD,
+  total,
+  covered,
+  uncovered,
+  percentage: pct,
+  passed,
+  stories: rows,
+};
+writeFileSync(join(OUT_DIR, "component-coverage.json"), JSON.stringify(json, null, 2));
+
+// Markdown
+const statusEmoji = passed ? "✅" : "❌";
+const uncoveredList = rows
+  .filter((r) => !r.covered)
+  .map((r) => `| \`${r.path}\` | ❌ No spec |`)
+  .join("\n");
+
+const coveredList = rows
+  .filter((r) => r.covered)
+  .map((r) => `| \`${r.path}\` | ✅ Covered |`)
+  .join("\n");
+
+const md = `# Component / Story Coverage Report
+
+${statusEmoji} **${pct}% coverage** (${covered} / ${total} stories have Playwright specs) — threshold: ${THRESHOLD}%
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Total stories | ${total} |
+| Covered by specs | ${covered} |
+| Not covered | ${uncovered} |
+| Coverage % | ${pct}% |
+| Threshold | ${THRESHOLD}% |
+| Status | ${passed ? "PASS ✅" : "FAIL ❌"} |
+
+## Coverage metric
+
+For this SCSS-only library, "coverage" means every Storybook story (**.stories.js**)
+in \`sam-styles/packages/\` has at least one matching Playwright spec in \`tests/storybook/\`.
+
+## Uncovered stories
+
+${uncovered === 0 ? "_All stories are covered_ 🎉" : `| Story file | Status |\n|------------|--------|\n${uncoveredList}`}
+
+## Covered stories
+
+| Story file | Status |
+|------------|--------|
+${coveredList}
+`;
+
+writeFileSync(join(OUT_DIR, "component-coverage.md"), md);
+
+// ── Console output ────────────────────────────────────────────────────────────
+
+process.stdout.write(`\nComponent/Story Coverage\n`);
+process.stdout.write(`  Stories:   ${total}\n`);
+process.stdout.write(`  Covered:   ${covered}\n`);
+process.stdout.write(`  Uncovered: ${uncovered}\n`);
+process.stdout.write(`  Coverage:  ${pct}% (threshold: ${THRESHOLD}%)\n`);
+process.stdout.write(`  Status:    ${passed ? "PASS ✅" : "FAIL ❌"}\n\n`);
+
+if (!passed) {
+  process.stderr.write(
+    `Coverage ${pct}% is below the required threshold of ${THRESHOLD}%.\n` +
+      `Add Playwright specs in tests/storybook/ for the uncovered stories listed above.\n` +
+      `See coverage/component-coverage.md for the full report.\n`
+  );
+  process.exit(1);
+}
+
+process.exit(0);

--- a/scripts/coverage-report.mjs
+++ b/scripts/coverage-report.mjs
@@ -21,7 +21,13 @@
  *   node scripts/coverage-report.mjs [--threshold=<n>]
  */
 
-import { readdirSync, readFileSync, mkdirSync, writeFileSync, existsSync } from "fs";
+import {
+  readdirSync,
+  readFileSync,
+  mkdirSync,
+  writeFileSync,
+  existsSync,
+} from "fs";
 import { join, dirname, relative } from "path";
 import { fileURLToPath } from "url";
 
@@ -39,8 +45,8 @@ const thresholdArg = process.argv.find((a) => a.startsWith("--threshold="));
 const THRESHOLD = thresholdArg
   ? parseInt(thresholdArg.split("=")[1], 10)
   : process.env.COVERAGE_THRESHOLD
-  ? parseInt(process.env.COVERAGE_THRESHOLD, 10)
-  : 35;
+    ? parseInt(process.env.COVERAGE_THRESHOLD, 10)
+    : 35;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -66,7 +72,9 @@ function walkFiles(dir, predicate) {
  */
 function buildCoveredSet(specsDir) {
   const covered = new Set();
-  const specFiles = readdirSync(specsDir).filter((f) => f.endsWith(".spec.mjs"));
+  const specFiles = readdirSync(specsDir).filter((f) =>
+    f.endsWith(".spec.mjs")
+  );
 
   for (const file of specFiles) {
     // Stem as a fallback key (e.g. "accordion" from "accordion.spec.mjs")
@@ -112,7 +120,9 @@ function storyMatchKeys(relPath) {
 
 // ── Main ──────────────────────────────────────────────────────────────────────
 
-const storyFiles = walkFiles(PACKAGES_DIR, (name) => name.endsWith(".stories.js"));
+const storyFiles = walkFiles(PACKAGES_DIR, (name) =>
+  name.endsWith(".stories.js")
+);
 const coveredKeys = buildCoveredSet(SPECS_DIR);
 
 const rows = storyFiles.map((absPath) => {
@@ -142,7 +152,10 @@ const json = {
   passed,
   stories: rows,
 };
-writeFileSync(join(OUT_DIR, "component-coverage.json"), JSON.stringify(json, null, 2));
+writeFileSync(
+  join(OUT_DIR, "component-coverage.json"),
+  JSON.stringify(json, null, 2)
+);
 
 // Markdown
 const statusEmoji = passed ? "✅" : "❌";


### PR DESCRIPTION
## What changed

Wires up component/story coverage reporting for CI as described in #772.

For a SCSS-only library with no JS runtime, traditional line/branch coverage doesn't apply. The coverage metric used here is:

> **Every Storybook story (`.stories.js`) in `sam-styles/packages/` should have at least one matching Playwright smoke-test spec in `tests/storybook/`.**

Current baseline after Storybook ID matching fixes: **46% (24 / 52 stories covered)** — threshold set at **35%** so CI passes at the baseline. Follow-up parent issue #774 tracks raising coverage toward 80–90%, with sub-issues #775–#778 covering the remaining story groups.

### Files changed

**`scripts/coverage-report.mjs`** *(new)*
- Walks `sam-styles/packages/` to enumerate all `.stories.js` files
- Cross-references against Playwright specs in `tests/storybook/`, including Storybook `title` / named-export generated IDs
- Emits `coverage/component-coverage.json` (machine-readable) and `coverage/component-coverage.md` (human-readable table)
- Exits 1 if coverage falls below the configured threshold; threshold overridable via `--threshold=N` or `COVERAGE_THRESHOLD` env var and validated as an integer from 0–100

**`package.json`**
- Adds `"coverage": "node scripts/coverage-report.mjs --threshold=35"` script

**`.github/workflows/test.yml`**
- Adds `pull-requests: write` permission (needed to post PR comment on same-repo PRs)
- Adds **Run component/story coverage check** step (`npm run coverage`) — CI check fails if below threshold
- Adds **Post coverage report as PR comment** step via `actions/github-script` — upserts a markdown report comment on same-repo PR runs
- Adds **Upload coverage report artifact** step — uploads `coverage/component-coverage.json` + `.md` on every run (including failures)

**`AGENTS.md`** / **`CONTRIBUTING.md`**
- Documents the coverage metric, current threshold, target (80–90%), and how to raise the threshold

## Follow-up coverage work

- Parent tracking issue: #774
- Sub-issues for independently-grabbable coverage slices: #775, #776, #777, #778

## How to test

**Locally:**

```bash
# Install deps if needed
npm ci

# Run the coverage check
npm run coverage
# Expected: "46% (threshold: 35%) — PASS ✅"
# Outputs: coverage/component-coverage.json and coverage/component-coverage.md

# Verify invalid threshold handling
node scripts/coverage-report.mjs --threshold=abc
# Expected: exits 1 with "Invalid coverage threshold \"abc\". Use an integer from 0 to 100."

# Verify it fails below threshold
COVERAGE_THRESHOLD=99 node scripts/coverage-report.mjs
# Expected: exits 1 with "Coverage 46% is below the required threshold of 99%"

# Confirm stylelint still passes
npm test

# Confirm SCSS compilation still passes
npm run compile:check
```

**In CI (after PR is opened):**
- The `Test` workflow runs the coverage check as a named step — verify it shows green in the Actions run
- A PR comment titled "Component / Story Coverage Report" should appear (or update) with the markdown table on same-repo PRs
- The `component-coverage-report` artifact should be downloadable from the Actions run summary

## Closes

Closes #772
