### PR TITLE
ci: lock down npm publish workflow against unauthorized OIDC use

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,3 @@
 # default owners. This is a merge-time guardrail against unauthorized
 # modifications to the OIDC/npm publish path (see docs/npm-publish-runbook.md).
 /.github/   @GSA/sam-shared-frontend-admin @christyhermansen @GSA/sam-shared-frontend
-

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,4 +11,4 @@
 # DevSecOps (sam-shared-frontend-admin) review in addition to the
 # default owners. This is a merge-time guardrail against unauthorized
 # modifications to the OIDC/npm publish path (see docs/npm-publish-runbook.md).
-/.github/   @GSA/sam-shared-frontend-admin @christyhermansen @GSA/sam-shared-frontend
+/.github/   @GSA/sam-shared-frontend-admin @christyhermansen

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,3 +7,9 @@
 # review when someone opens a pull request.
 *       @christyhermansen @GSA/sam-shared-frontend
 
+# Changes to GitHub Actions workflows and repo configuration require
+# DevSecOps (sam-shared-frontend-admin) review in addition to the
+# default owners. This is a merge-time guardrail against unauthorized
+# modifications to the OIDC/npm publish path (see docs/npm-publish-runbook.md).
+/.github/   @GSA/sam-shared-frontend-admin @christyhermansen @GSA/sam-shared-frontend
+

--- a/docs/npm-publish-runbook.md
+++ b/docs/npm-publish-runbook.md
@@ -12,11 +12,11 @@ See also: `.github/workflows/publish.yml` for the full workflow source.
 Three independent guardrails must all be satisfied before a live publish can
 reach npm. An attacker would need to defeat all three simultaneously.
 
-| Layer | What it guards | Where it lives |
-|---|---|---|
-| 1 — CODEOWNERS | Merge-time: any change to `/.github/` requires `@GSA/sam-shared-frontend-admin` review | `CODEOWNERS` |
-| 2 — Branch protection | Merge-time: `master` requires a passing PR review, code-owner approval, and forbids direct pushes | GitHub repo Settings → Branches |
-| 3 — Environment gate | Run-time: the `npm-publish` environment pauses every publish job for a named human approver **before** OIDC mints a credential | GitHub repo Settings → Environments → `npm-publish` |
+| Layer                 | What it guards                                                                                                                 | Where it lives                                      |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
+| 1 — CODEOWNERS        | Merge-time: any change to `/.github/` requires `@GSA/sam-shared-frontend-admin` review                                         | `CODEOWNERS`                                        |
+| 2 — Branch protection | Merge-time: `master` requires a passing PR review, code-owner approval, and forbids direct pushes                              | GitHub repo Settings → Branches                     |
+| 3 — Environment gate  | Run-time: the `npm-publish` environment pauses every publish job for a named human approver **before** OIDC mints a credential | GitHub repo Settings → Environments → `npm-publish` |
 
 Layers 1 and 2 prevent an unauthorized workflow change from landing on
 `master`. Layer 3 catches anything that somehow slips through — even a
@@ -56,7 +56,7 @@ off as done and record the date.
 ### Layer 2 — Branch protection on `master`
 
 - [ ] **Required status checks** — add `quality-gates` and `test` as required
-  checks (or the merged `build` reusable workflow status)
+      checks (or the merged `build` reusable workflow status)
 - [ ] **Require a pull request before merging** — at least 1 approving review
 - [ ] **Require review from Code Owners** — ensures `CODEOWNERS` is enforced
 - [ ] **Restrict pushes** — no direct pushes to `master`; only PRs
@@ -67,11 +67,11 @@ Location: `https://github.com/GSA/sam-styles/settings/branches`
 ### Layer 3 — `npm-publish` environment
 
 - [ ] **Required reviewers** — add `@GSA/sam-shared-frontend-admin` (and/or
-  specific individuals); at least one approval required
+      specific individuals); at least one approval required
 - [ ] **Deployment branches** — restrict to the `master` branch only (prevents
-  the environment from being triggered by a feature branch)
+      the environment from being triggered by a feature branch)
 - [ ] **Wait timer** (optional) — add a short wait (e.g. 5 min) as an extra
-  speed-bump if desired
+      speed-bump if desired
 
 Location: `https://github.com/GSA/sam-styles/settings/environments`
 
@@ -79,7 +79,7 @@ Location: `https://github.com/GSA/sam-styles/settings/environments`
 
 - [ ] Log in to npmjs.com as the `@gsa-sam` org owner
 - [ ] Navigate to the `@gsa-sam/sam-styles` package → **Settings** →
-  **Trusted Publishers**
+      **Trusted Publishers**
 - [ ] Add a GitHub Actions publisher:
   - **Organization**: `GSA`
   - **Repository**: `sam-styles`

--- a/docs/npm-publish-runbook.md
+++ b/docs/npm-publish-runbook.md
@@ -55,8 +55,12 @@ off as done and record the date.
 
 ### Layer 2 — Branch protection on `master`
 
-- [ ] **Required status checks** — add `quality-gates` and `test` as required
-      checks (or the merged `build` reusable workflow status)
+- [ ] **Required status checks** — add the PR quality-gate check runs so a PR
+      can't merge until they pass. These are named `{workflow} / {job}`; in
+      this repo the relevant ones are `Test / test`, `Build-Storybook / Lint`,
+      `Build-Storybook / Format-Check`, and `Build-Storybook / Build-Storybook-Assets`.
+      (Note: `quality-gates` is a job in the release-triggered `publish.yml`
+      and does **not** appear as a PR status check — don't reference it here.)
 - [ ] **Require a pull request before merging** — at least 1 approving review
 - [ ] **Require review from Code Owners** — ensures `CODEOWNERS` is enforced
 - [ ] **Restrict pushes** — no direct pushes to `master`; only PRs

--- a/docs/npm-publish-runbook.md
+++ b/docs/npm-publish-runbook.md
@@ -1,0 +1,116 @@
+# npm Publish Runbook
+
+This document describes the security model and approval flow for publishing
+`@gsa-sam/sam-styles` to the public npm registry.
+
+See also: `.github/workflows/publish.yml` for the full workflow source.
+
+---
+
+## Security layers (defence-in-depth)
+
+Three independent guardrails must all be satisfied before a live publish can
+reach npm. An attacker would need to defeat all three simultaneously.
+
+| Layer | What it guards | Where it lives |
+|---|---|---|
+| 1 — CODEOWNERS | Merge-time: any change to `/.github/` requires `@GSA/sam-shared-frontend-admin` review | `CODEOWNERS` |
+| 2 — Branch protection | Merge-time: `master` requires a passing PR review, code-owner approval, and forbids direct pushes | GitHub repo Settings → Branches |
+| 3 — Environment gate | Run-time: the `npm-publish` environment pauses every publish job for a named human approver **before** OIDC mints a credential | GitHub repo Settings → Environments → `npm-publish` |
+
+Layers 1 and 2 prevent an unauthorized workflow change from landing on
+`master`. Layer 3 catches anything that somehow slips through — even a
+legitimately-merged change cannot actually publish until a human explicitly
+approves the pending deployment.
+
+---
+
+## How the approval flow works at runtime
+
+1. A GitHub Release is published (or a maintainer triggers `workflow_dispatch`
+   with `dry-run: true`).
+2. The `quality-gates` and `test` jobs run first (lint, SCSS compile,
+   Playwright smoke tests).
+3. On success, the `publish` job is queued **but paused** at the
+   `environment: npm-publish` gate.
+4. GitHub sends a notification to the required reviewers configured on the
+   `npm-publish` environment.
+5. A named DevSecOps approver reviews the pending deployment in
+   **Actions → the workflow run → Review deployments** and clicks **Approve**.
+6. Only after approval does the job continue — at which point GitHub mints a
+   short-lived OIDC credential that npm trusts because this repo + workflow
+   filename are registered as the package's Trusted Publisher.
+7. `npm publish` (or `npm publish --dry-run`) runs with that credential. No
+   long-lived token is stored anywhere in the repo or in GitHub Secrets.
+
+If the approver clicks **Reject**, the job is cancelled and nothing is
+published.
+
+---
+
+## One-time setup checklist (DevSecOps / repo admin)
+
+These steps must be completed once before the first live publish. Check each
+off as done and record the date.
+
+### Layer 2 — Branch protection on `master`
+
+- [ ] **Required status checks** — add `quality-gates` and `test` as required
+  checks (or the merged `build` reusable workflow status)
+- [ ] **Require a pull request before merging** — at least 1 approving review
+- [ ] **Require review from Code Owners** — ensures `CODEOWNERS` is enforced
+- [ ] **Restrict pushes** — no direct pushes to `master`; only PRs
+- [ ] **Do not allow bypassing** — admins also subject to these rules
+
+Location: `https://github.com/GSA/sam-styles/settings/branches`
+
+### Layer 3 — `npm-publish` environment
+
+- [ ] **Required reviewers** — add `@GSA/sam-shared-frontend-admin` (and/or
+  specific individuals); at least one approval required
+- [ ] **Deployment branches** — restrict to the `master` branch only (prevents
+  the environment from being triggered by a feature branch)
+- [ ] **Wait timer** (optional) — add a short wait (e.g. 5 min) as an extra
+  speed-bump if desired
+
+Location: `https://github.com/GSA/sam-styles/settings/environments`
+
+### npm Trusted Publisher registration
+
+- [ ] Log in to npmjs.com as the `@gsa-sam` org owner
+- [ ] Navigate to the `@gsa-sam/sam-styles` package → **Settings** →
+  **Trusted Publishers**
+- [ ] Add a GitHub Actions publisher:
+  - **Organization**: `GSA`
+  - **Repository**: `sam-styles`
+  - **Workflow filename**: `publish.yml`
+  - **Environment name**: `npm-publish`
+- [ ] Once registered, flip `DRY_RUN` to `false`:
+  - Go to `https://github.com/GSA/sam-styles/settings/variables/actions`
+  - Set the `DRY_RUN` repository variable (or environment variable on
+    `npm-publish`) to `false`
+  - Alternatively, edit the default in `publish.yml` — but prefer the
+    variable so it can be toggled without a code change
+
+---
+
+## Verifying the gate is active (smoke test)
+
+1. Trigger a manual dry-run: **Actions → Publish to npm → Run workflow** →
+   leave `dry-run: true` → **Run workflow**.
+2. Watch the run. After `quality-gates` and `test` pass, the `publish` job
+   should show **"Waiting for review"** under the `npm-publish` environment.
+3. Approve it. The job should proceed, run `npm publish --dry-run`, and exit 0.
+4. Confirm in the job logs that `npm publish --dry-run` ran (look for
+   `npm notice` tarball output and the "dry-run" notice).
+
+If the job does **not** pause for review, the environment gate is misconfigured
+— stop and fix before registering the Trusted Publisher.
+
+---
+
+## Related files
+
+- `.github/workflows/publish.yml` — the publish workflow
+- `CODEOWNERS` — enforces DevSecOps review on `/.github/` changes
+- `docs/npm-publish-runbook.md` — this file


### PR DESCRIPTION
## What changed

Adds layered merge-time and run-time guardrails to prevent unauthorized use of the OIDC Trusted Publishing identity in `.github/workflows/publish.yml`. Follow-on from #737 / PR #770.

### Files changed

**`CODEOWNERS`**
- Adds a `/.github/` entry requiring `@GSA/sam-shared-frontend-admin` review for any change to GitHub Actions workflows or repo configuration.
- This is **merge-time layer 1**: an unauthorized workflow edit cannot land on `master` without explicit DevSecOps sign-off.

**`docs/npm-publish-runbook.md`** *(new)*
- Documents the full three-layer defence-in-depth model:
  - Layer 1 — CODEOWNERS (merge-time)
  - Layer 2 — branch protection on `master` (merge-time)
  - Layer 3 — `npm-publish` environment required-reviewer gate (run-time, pauses OIDC minting)
- Step-by-step runtime approval flow (how the environment gate pauses the publish job before OIDC mints a credential).
- One-time DevSecOps setup checklist covering branch protection, environment protection rules, and Trusted Publisher registration.
- Smoke-test procedure to verify the environment gate is active before going live.

## How to test

**Automated checks (run locally):**

```bash
npm ci
npm test                # stylelint — exits 0
npm run compile:check   # SCSS compilation — prints "SCSS compilation: OK"
```

Both checks passed on this branch before opening the PR.

**Manual / HITL verification (DevSecOps / repo admin):**

These steps cannot be automated — follow the checklist in `docs/npm-publish-runbook.md`:

1. **Branch protection on `master`** — confirm required PR review, code-owner review required, no direct pushes are enabled (`Settings → Branches`).
2. **`npm-publish` environment** — confirm required reviewers (`@GSA/sam-shared-frontend-admin`) and deployment branch restricted to `master` (`Settings → Environments → npm-publish`).
3. **Smoke test the gate** — trigger a manual dry-run dispatch (`Actions → Publish to npm → Run workflow`, leave `dry-run: true`). After quality gates pass, the publish job should pause at `"Waiting for review"`. Approve it and confirm `npm publish --dry-run` runs successfully in the logs.
4. **Only after all above are verified** — register the npm Trusted Publisher connection (Org: `GSA`, Repo: `sam-styles`, Workflow: `publish.yml`, Environment: `npm-publish`) and set `DRY_RUN=false`.

## Closes

Closes #779
