### PR TITLE
ci: align publish workflow to existing release environment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,12 +16,12 @@ name: Publish to npm
 #
 # Why key on Release (not a raw `push: tags`): publishing a Release is a
 # deliberate, auditable act. It gives DevSecOps a clear HITL approval point
-# and pairs with the `npm-publish` environment's required reviewers. A raw
+# and pairs with the `release` environment's required reviewers. A raw
 # tag push is quiet and unauthenticated by comparison, so the live
 # `npm publish` only happens on a published *Release*.
 #
 # Security model (locked-down access):
-#   - Runs only in the `npm-publish` GitHub Actions environment, which
+#   - Runs only in the `release` GitHub Actions environment, which
 #     DevSecOps can gate with required reviewers / protection rules.
 #   - Uses npm Trusted Publishing (OIDC) — no long-lived token stored in
 #     the repo. The `id-token: write` permission mints a short-lived
@@ -31,7 +31,7 @@ name: Publish to npm
 #        Publisher = GitHub Actions
 #        Organization = GSA, Repository = sam-styles
 #        Workflow filename = publish.yml
-#        Environment name = npm-publish)
+#        Environment name = release)
 #   - Quality gates (lint + tests + SCSS compile) must pass before publish.
 #
 # HITL handoff to DevSecOps:
@@ -92,7 +92,7 @@ jobs:
   publish:
     needs: [quality-gates, test]
     runs-on: ubuntu-latest
-    environment: npm-publish
+    environment: release
     permissions:
       contents: read
       id-token: write # required for npm Trusted Publishing (OIDC)

--- a/docs/npm-publish-runbook.md
+++ b/docs/npm-publish-runbook.md
@@ -74,9 +74,19 @@ Location: `https://github.com/GSA/sam-styles/settings/branches`
 > repo with required reviewers (`@GSA/sam-shared-frontend`) and a deployment
 > branch policy restricting it to `master`. The boxes below are checked to
 > record that state; re-verify if the environment is ever recreated.
+>
+> **⚠️ Reviewer scope is broader than DevSecOps.** The current required
+> reviewer is the whole `@GSA/sam-shared-frontend` team, not a DevSecOps-only
+> group. Any member of that team can approve a pending publish — so the
+> run-time gate today gates on "a frontend maintainer", not "DevSecOps". If
+> the intent is DevSecOps-only approval, change the required reviewers to
+> `@GSA/sam-shared-frontend-admin` (or a named DevSecOps individual) before
+> going live. Until then, do not treat Layer 3 as a DevSecOps-exclusive
+> control.
 
 - [x] **Required reviewers** — `@GSA/sam-shared-frontend` is set; at least one
-      approval required
+      approval required (see scope caveat above — tighten to
+      `@GSA/sam-shared-frontend-admin` for DevSecOps-only approval)
 - [x] **Deployment branches** — restricted to the `master` branch only
       (prevents the environment from being triggered by a feature branch)
 - [ ] **Wait timer** (optional) — add a short wait (e.g. 5 min) as an extra

--- a/docs/npm-publish-runbook.md
+++ b/docs/npm-publish-runbook.md
@@ -12,11 +12,11 @@ See also: `.github/workflows/publish.yml` for the full workflow source.
 Three independent guardrails must all be satisfied before a live publish can
 reach npm. An attacker would need to defeat all three simultaneously.
 
-| Layer                 | What it guards                                                                                                                 | Where it lives                                      |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
-| 1 — CODEOWNERS        | Merge-time: any change to `/.github/` requires `@GSA/sam-shared-frontend-admin` review                                         | `CODEOWNERS`                                        |
-| 2 — Branch protection | Merge-time: `master` requires a passing PR review, code-owner approval, and forbids direct pushes                              | GitHub repo Settings → Branches                     |
-| 3 — Environment gate  | Run-time: the `npm-publish` environment pauses every publish job for a named human approver **before** OIDC mints a credential | GitHub repo Settings → Environments → `npm-publish` |
+| Layer                 | What it guards                                                                                                             | Where it lives                                  |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| 1 — CODEOWNERS        | Merge-time: any change to `/.github/` requires `@GSA/sam-shared-frontend-admin` review                                     | `CODEOWNERS`                                    |
+| 2 — Branch protection | Merge-time: `master` requires a passing PR review, code-owner approval, and forbids direct pushes                          | GitHub repo Settings → Branches                 |
+| 3 — Environment gate  | Run-time: the `release` environment pauses every publish job for a named human approver **before** OIDC mints a credential | GitHub repo Settings → Environments → `release` |
 
 Layers 1 and 2 prevent an unauthorized workflow change from landing on
 `master`. Layer 3 catches anything that somehow slips through — even a
@@ -32,9 +32,9 @@ approves the pending deployment.
 2. The `quality-gates` and `test` jobs run first (lint, SCSS compile,
    Playwright smoke tests).
 3. On success, the `publish` job is queued **but paused** at the
-   `environment: npm-publish` gate.
+   `environment: release` gate.
 4. GitHub sends a notification to the required reviewers configured on the
-   `npm-publish` environment.
+   `release` environment.
 5. A named DevSecOps approver reviews the pending deployment in
    **Actions → the workflow run → Review deployments** and clicks **Approve**.
 6. Only after approval does the job continue — at which point GitHub mints a
@@ -68,18 +68,28 @@ off as done and record the date.
 
 Location: `https://github.com/GSA/sam-styles/settings/branches`
 
-### Layer 3 — `npm-publish` environment
+### Layer 3 — `release` environment
 
-- [ ] **Required reviewers** — add `@GSA/sam-shared-frontend-admin` (and/or
-      specific individuals); at least one approval required
-- [ ] **Deployment branches** — restrict to the `master` branch only (prevents
-      the environment from being triggered by a feature branch)
+> **Status: already configured.** The `release` environment exists on the
+> repo with required reviewers (`@GSA/sam-shared-frontend`) and a deployment
+> branch policy restricting it to `master`. The boxes below are checked to
+> record that state; re-verify if the environment is ever recreated.
+
+- [x] **Required reviewers** — `@GSA/sam-shared-frontend` is set; at least one
+      approval required
+- [x] **Deployment branches** — restricted to the `master` branch only
+      (prevents the environment from being triggered by a feature branch)
 - [ ] **Wait timer** (optional) — add a short wait (e.g. 5 min) as an extra
       speed-bump if desired
 
 Location: `https://github.com/GSA/sam-styles/settings/environments`
 
 ### npm Trusted Publisher registration
+
+> **Note (DevSecOps):** the OIDC wiring is more involved here because the
+> `@gsa-sam` org publishes with **immutable tokens**. Confirm with the org
+> owner how the Trusted Publisher / OIDC exchange interacts with the immutable
+> token policy before flipping `DRY_RUN` to `false`.
 
 - [ ] Log in to npmjs.com as the `@gsa-sam` org owner
 - [ ] Navigate to the `@gsa-sam/sam-styles` package → **Settings** →
@@ -88,11 +98,11 @@ Location: `https://github.com/GSA/sam-styles/settings/environments`
   - **Organization**: `GSA`
   - **Repository**: `sam-styles`
   - **Workflow filename**: `publish.yml`
-  - **Environment name**: `npm-publish`
+  - **Environment name**: `release`
 - [ ] Once registered, flip `DRY_RUN` to `false`:
   - Go to `https://github.com/GSA/sam-styles/settings/variables/actions`
   - Set the `DRY_RUN` repository variable (or environment variable on
-    `npm-publish`) to `false`
+    `release`) to `false`
   - Alternatively, edit the default in `publish.yml` — but prefer the
     variable so it can be toggled without a code change
 
@@ -103,7 +113,7 @@ Location: `https://github.com/GSA/sam-styles/settings/environments`
 1. Trigger a manual dry-run: **Actions → Publish to npm → Run workflow** →
    leave `dry-run: true` → **Run workflow**.
 2. Watch the run. After `quality-gates` and `test` pass, the `publish` job
-   should show **"Waiting for review"** under the `npm-publish` environment.
+   should show **"Waiting for review"** under the `release` environment.
 3. Approve it. The job should proceed, run `npm publish --dry-run`, and exit 0.
 4. Confirm in the job logs that `npm publish --dry-run` ran (look for
    `npm notice` tarball output and the "dry-run" notice).


### PR DESCRIPTION
## What changed

Follow-up to #780. DevSecOps (@mgetzflex) had already provisioned the npm Trusted Publisher and the GitHub Actions environment under the name **`release`**, but the merged workflow and runbook referenced a non-existent **`npm-publish`** environment. As written, the run-time environment gate (Layer 3 of the defence-in-depth model) would never engage, because `environment: npm-publish` doesn't match any configured environment.

This PR aligns the workflow and docs to the environment that actually exists.

**`.github/workflows/publish.yml`**
- `environment: npm-publish` → `environment: release` (the actual gate)
- Updated the security-model comment block to reference `release`

**`docs/npm-publish-runbook.md`**
- All references updated from `npm-publish` to `release`
- Marked the **Layer 3** checklist items done — verified via the GitHub API that the `release` environment already has required reviewers (`@GSA/sam-shared-frontend`) and a `master`-only deployment branch policy
- Added a DevSecOps note that the `@gsa-sam` org publishes with **immutable tokens**, which needs confirming against the Trusted Publisher / OIDC exchange before flipping `DRY_RUN=false`

## Why

The environment name in the workflow must match the environment configured on the repo (and registered as the npm Trusted Publisher) or the human-approval gate silently does nothing. @mgetzflex confirmed the environment is `release` on npmjs.

## How to test

This is a CI/docs-only change (no runtime code):

- `grep -rn "npm-publish" .github/workflows/publish.yml` → returns nothing
- Confirm `.github/workflows/publish.yml` uses `environment: release`
- Confirm the runbook consistently references `release`
- YAML validity: `npx js-yaml .github/workflows/publish.yml > /dev/null`

Full end-to-end verification (dry-run smoke test) is a HITL DevSecOps step documented in the runbook and can't be exercised from the diff.

## Related

Refs #779, #780

## Screenshots

N/A — CI/docs changes only.
