### PR TITLE
build: harden manual npm publish dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,8 @@ name: Publish to npm
 # Publishes @gsa-sam/sam-styles to the public npm registry.
 #
 # Trigger: a full GitHub Release is published (activity type `released`,
-# which points at a version tag, e.g. v3.1.0). Manual dispatch is also
-# allowed for dry-run rehearsals.
+# which points at a version tag, e.g. v3.1.0). Manual dispatch is
+# rehearsal-only and must run in dry-run mode.
 #
 # Why `released` and not `published`: `published` also fires for
 # pre-releases (e.g. v3.1.0-beta.1). Because we publish with npm's default
@@ -35,12 +35,15 @@ name: Publish to npm
 #   - Quality gates (lint + tests + SCSS compile) must pass before publish.
 #
 # HITL handoff to DevSecOps:
-#   Until the Trusted Publisher connection is live, this workflow runs
-#   `npm publish --dry-run` only (DRY_RUN defaults to "true"). DevSecOps:
+#   Until the Trusted Publisher connection is live, Release-triggered runs
+#   publish with `npm publish --dry-run` only (DRY_RUN defaults to "true").
+#   DevSecOps:
 #     1. Registers the Trusted Publisher on npmjs (values above).
-#     2. Flips the workflow to a live publish by setting the repo/environment
-#        variable  DRY_RUN = false  (Settings → Secrets and variables →
-#        Actions → Variables), or edits the default below.
+#     2. Enables Release-triggered live publishing by setting the
+#        repo/environment variable  DRY_RUN = false  (Settings → Secrets and
+#        variables → Actions → Variables), or edits the default below.
+#   Manual workflow_dispatch runs are always rehearsal-only, regardless of
+#   DRY_RUN, and cannot perform a live publish.
 #
 # Note on workflow_dispatch rehearsals: a manual dry-run against an
 # already-published version (e.g. the current 3.0.25) will verify the
@@ -137,11 +140,14 @@ jobs:
       - name: Determine dry-run mode
         id: mode
         run: |
-          # Priority: workflow_dispatch input > repo/env variable DRY_RUN > default true.
-          # Only a published Release (or a manual dispatch with dry-run=false)
-          # may perform a live publish.
+          # workflow_dispatch is rehearsal-only. Only a published Release may
+          # perform a live publish, controlled by repo/env variable DRY_RUN.
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             DRY="${{ inputs.dry-run }}"
+            if [ "$DRY" != "true" ]; then
+              echo "::error::workflow_dispatch runs must use dry-run=true. Publish a GitHub Release to run a live publish."
+              exit 1
+            fi
           else
             DRY="${{ vars.DRY_RUN }}"
           fi
@@ -159,7 +165,7 @@ jobs:
           echo "Publish dry-run mode: $DRY"
 
       - name: Publish (dry-run)
-        if: steps.mode.outputs.dry-run == 'true'
+        if: steps.mode.outputs['dry-run'] == 'true'
         run: npm publish --dry-run --access public
 
       # Live publish via OIDC Trusted Publishing. No token env is set — npm
@@ -167,5 +173,5 @@ jobs:
       # workflow are registered as the package's Trusted Publisher. This is
       # the only supported publish path; there is no long-lived-token fallback.
       - name: Publish (live, OIDC Trusted Publishing)
-        if: steps.mode.outputs.dry-run == 'false'
+        if: github.event_name == 'release' && steps.mode.outputs['dry-run'] == 'false'
         run: npm publish --access public

--- a/docs/npm-publish-runbook.md
+++ b/docs/npm-publish-runbook.md
@@ -27,8 +27,10 @@ approves the pending deployment.
 
 ## How the approval flow works at runtime
 
-1. A GitHub Release is published (or a maintainer triggers `workflow_dispatch`
-   with `dry-run: true`).
+1. A GitHub Release is published (for live publish or Release dry-run), or a
+   maintainer triggers rehearsal-only `workflow_dispatch` with `dry-run: true`.
+   Manual `workflow_dispatch` runs with `dry-run: false` fail before any
+   publish command can run.
 2. The `quality-gates` and `test` jobs run first (lint, SCSS compile,
    Playwright smoke tests).
 3. On success, the `publish` job is queued **but paused** at the
@@ -109,24 +111,31 @@ Location: `https://github.com/GSA/sam-styles/settings/environments`
   - **Repository**: `sam-styles`
   - **Workflow filename**: `publish.yml`
   - **Environment name**: `release`
-- [ ] Once registered, flip `DRY_RUN` to `false`:
+- [ ] Once registered, enable Release-triggered live publishing by flipping
+      `DRY_RUN` to `false`:
   - Go to `https://github.com/GSA/sam-styles/settings/variables/actions`
   - Set the `DRY_RUN` repository variable (or environment variable on
     `release`) to `false`
   - Alternatively, edit the default in `publish.yml` — but prefer the
     variable so it can be toggled without a code change
+  - This does **not** enable manual live publishing; `workflow_dispatch`
+    remains rehearsal-only and still requires `dry-run: true`
 
 ---
 
 ## Verifying the gate is active (smoke test)
 
-1. Trigger a manual dry-run: **Actions → Publish to npm → Run workflow** →
-   leave `dry-run: true` → **Run workflow**.
+1. Trigger a manual rehearsal dry-run: **Actions → Publish to npm → Run
+   workflow** → leave `dry-run: true` → **Run workflow**.
 2. Watch the run. After `quality-gates` and `test` pass, the `publish` job
    should show **"Waiting for review"** under the `release` environment.
 3. Approve it. The job should proceed, run `npm publish --dry-run`, and exit 0.
 4. Confirm in the job logs that `npm publish --dry-run` ran (look for
    `npm notice` tarball output and the "dry-run" notice).
+5. Trigger a manual negative test: **Actions → Publish to npm → Run
+   workflow** → set `dry-run: false` → **Run workflow**. The publish job must
+   fail with `workflow_dispatch runs must use dry-run=true` before either
+   `npm publish --dry-run` or live `npm publish` runs.
 
 If the job does **not** pause for review, the environment gate is misconfigured
 — stop and fix before registering the Trusted Publisher.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   ],
   "scripts": {
     "test": "stylelint \"sam-styles/**/*.scss\"",
+    "test:publish-workflow": "node scripts/check-publish-workflow.mjs",
     "test:storybook": "playwright test",
     "compile:check": "node scripts/compile-check.mjs",
     "coverage": "node scripts/coverage-report.mjs --threshold=90",

--- a/scripts/check-publish-workflow.mjs
+++ b/scripts/check-publish-workflow.mjs
@@ -41,13 +41,15 @@ assert(
 );
 
 assert(
-  /if: github\.event_name == 'release' && steps\.mode\.outputs\['dry-run'\] == 'false'/.test(
+  /if:\s*github\.event_name\s*==\s*['"]release['"]\s*&&\s*steps\.mode\.outputs\[['"]dry-run['"]\]\s*==\s*['"]false['"]/.test(
     livePublishStep
   ),
   "Live publish must explicitly require the release event and dry-run=false."
 );
 assert(
-  /if: steps\.mode\.outputs\['dry-run'\] == 'true'/.test(dryRunPublishStep),
+  /if:\s*steps\.mode\.outputs\[['"]dry-run['"]\]\s*==\s*['"]true['"]/.test(
+    dryRunPublishStep
+  ),
   "Dry-run publish must still run when dry-run mode is true."
 );
 

--- a/scripts/check-publish-workflow.mjs
+++ b/scripts/check-publish-workflow.mjs
@@ -41,13 +41,13 @@ assert(
 );
 
 assert(
-  /if:\s*github\.event_name\s*==\s*['"]release['"]\s*&&\s*steps\.mode\.outputs\[['"]dry-run['"]\]\s*==\s*['"]false['"]/.test(
+  /if:\s*github\.event_name\s*==\s*(['"])release\1\s*&&\s*steps\.mode\.outputs\[(['"])dry-run\2\]\s*==\s*(['"])false\3/.test(
     livePublishStep
   ),
   "Live publish must explicitly require the release event and dry-run=false."
 );
 assert(
-  /if:\s*steps\.mode\.outputs\[['"]dry-run['"]\]\s*==\s*['"]true['"]/.test(
+  /if:\s*steps\.mode\.outputs\[(['"])dry-run\1\]\s*==\s*(['"])true\2/.test(
     dryRunPublishStep
   ),
   "Dry-run publish must still run when dry-run mode is true."

--- a/scripts/check-publish-workflow.mjs
+++ b/scripts/check-publish-workflow.mjs
@@ -1,0 +1,80 @@
+import { readFileSync } from "node:fs";
+
+const workflow = readFileSync(".github/workflows/publish.yml", "utf8");
+const runbook = readFileSync("docs/npm-publish-runbook.md", "utf8");
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function stepNamed(name) {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = workflow.match(
+    new RegExp(`- name: ${escaped}[\\s\\S]*?(?=\\n\\s*(?:#\\s*)?- name: |$)`)
+  );
+  return match?.[0] ?? "";
+}
+
+const modeStep = stepNamed("Determine dry-run mode");
+const livePublishStep = stepNamed("Publish (live, OIDC Trusted Publishing)");
+const dryRunPublishStep = stepNamed("Publish (dry-run)");
+
+assert(modeStep, 'Could not find the "Determine dry-run mode" step.');
+assert(livePublishStep, "Could not find the live publish step.");
+assert(dryRunPublishStep, "Could not find the dry-run publish step.");
+
+assert(
+  /if \[ "\$\{\{ github\.event_name \}\}" = "workflow_dispatch" \]; then/.test(
+    modeStep
+  ),
+  "Determine dry-run mode must branch on workflow_dispatch."
+);
+assert(
+  /if \[ "\$DRY" != "true" \]; then/.test(modeStep) &&
+    /::error::workflow_dispatch runs must use dry-run=true\. Publish a GitHub Release to run a live publish\./.test(
+      modeStep
+    ) &&
+    /exit 1/.test(modeStep),
+  "workflow_dispatch dry-run=false must fail loudly before publish."
+);
+
+assert(
+  /if: github\.event_name == 'release' && steps\.mode\.outputs\['dry-run'\] == 'false'/.test(
+    livePublishStep
+  ),
+  "Live publish must explicitly require the release event and dry-run=false."
+);
+assert(
+  /if: steps\.mode\.outputs\['dry-run'\] == 'true'/.test(dryRunPublishStep),
+  "Dry-run publish must still run when dry-run mode is true."
+);
+
+assert(
+  /quality-gates:\n\s+uses: \.\/\.github\/workflows\/build\.yml/.test(workflow),
+  "Existing reusable build quality gate must remain in the publish workflow."
+);
+for (const expectedStep of [
+  "Run tests (stylelint)",
+  "SCSS compilation check",
+  "Run Storybook smoke tests",
+]) {
+  assert(
+    workflow.includes(`- name: ${expectedStep}`),
+    `Existing publish quality gate step is missing: ${expectedStep}`
+  );
+}
+
+assert(
+  /manual (?:dispatch|workflow_dispatch).*rehearsal-only/is.test(
+    `${workflow}\n${runbook}`
+  ),
+  "Workflow comments/runbook must describe manual dispatch as rehearsal-only."
+);
+assert(
+  !/manual dispatch with dry-run=false/is.test(`${workflow}\n${runbook}`),
+  "Docs/comments must not imply manual dispatch with dry-run=false can live publish."
+);
+
+console.log("Publish workflow hardening checks passed.");


### PR DESCRIPTION
## What changed

Hardens the npm publish workflow so manual `workflow_dispatch` runs are rehearsal-only and live publishing can only happen from the GitHub Release event.

- `.github/workflows/publish.yml`
  - Fails loudly when `workflow_dispatch` is run with `dry-run: false`.
  - Keeps manual dispatch dry-run rehearsals working with `dry-run: true`.
  - Requires `github.event_name == 'release'` on the live `npm publish` step in addition to `dry-run == false`.
  - Preserves the existing publish quality gates.
- `docs/npm-publish-runbook.md`
  - Clarifies that manual dispatch is rehearsal-only.
  - Clarifies that `DRY_RUN=false` enables Release-triggered live publishing only.
  - Adds a manual negative smoke test for `workflow_dispatch` with `dry-run: false`.
- `scripts/check-publish-workflow.mjs`
  - Adds assertions for the publish workflow hardening requirements.
- `package.json`
  - Adds `npm run test:publish-workflow`.

## Why

The previous workflow allowed a manual dispatch with `dry-run: false`, and the live publish step was guarded only by the computed dry-run output. The protected `release` environment remains an important runtime control, but the workflow now adds defense-in-depth so manual live publish cannot be accidentally re-enabled by configuration drift.

## How to test

```bash
npx prettier --check .github/workflows/publish.yml docs/npm-publish-runbook.md scripts/check-publish-workflow.mjs package.json
npm run test:publish-workflow
npm test
npm run compile:check
```

All commands pass locally.

Full manual smoke tests are documented in `docs/npm-publish-runbook.md`:

1. Run manual dispatch with `dry-run: true`; it should proceed to dry-run publish after the environment approval gate.
2. Run manual dispatch with `dry-run: false`; it should fail with `workflow_dispatch runs must use dry-run=true` before publish.

## Related

Closes #787

## Screenshots

N/A — CI/workflow/docs changes only.
